### PR TITLE
Add GRUB_BTRFS_LIMIT

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -72,6 +72,11 @@ nkernel=("${GRUB_BTRFS_NKERNEL[@]}")
 ninit=("${GRUB_BTRFS_NINIT[@]}")
 ## Microcode(s) name(s)
 microcode=("${GRUB_BTRFS_INTEL_UCODE[@]}")
+## Limit to show in menu
+limit=("${GRUB_BTRFS_LIMIT[@]}")
+if [ -z "$limit" ]; then
+    limit=100
+fi
 
 ########################
 ### variables script ###
@@ -156,7 +161,7 @@ snapshots_entry()
 ## List of snapshots on filesystem
 snapshot_list()
 {
-	for snap in $(btrfs subvolume list -sa /); do
+	for snap in $(btrfs subvolume list -sa / | tac); do
 		IFS=$oldIFS
 		snap=($snap)
 		local snap_path_name=${snap[@]:13:${#snap[@]}}
@@ -249,6 +254,7 @@ title_format()
 list_kernels_initramfs()
 {
 	IFS=$'\n'
+    c=0
 	for item in $(snapshot_list); do
 		IFS=$oldIFS
 		item=($item)
@@ -276,6 +282,10 @@ list_kernels_initramfs()
 		title_format
 		# echo "${title_menu[*]}"
 		snapshots_entry
+        c=$((1+$c))
+        if [[ $c -gt $limit ]]; then
+            break;
+        fi
 	done
 	IFS=$oldIFS
 }

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -74,6 +74,12 @@ ninit=("${GRUB_BTRFS_NINIT[@]}")
 microcode=("${GRUB_BTRFS_INTEL_UCODE[@]}")
 ## Limit to show in menu
 limit=("${GRUB_BTRFS_LIMIT[@]:-100}")
+## How to sort
+subvolsort=${GRUB_BTRFS_SUBVOLUME_SORT:-"descending"}
+case "${subvolsort}" in
+    ascending)          btrfssubvolsort=("--sort=+rootid");;
+    *)                  btrfssubvolsort=("--sort=-rootid")
+esac
 
 ########################
 ### variables script ###
@@ -158,7 +164,7 @@ snapshots_entry()
 ## List of snapshots on filesystem
 snapshot_list()
 {
-	for snap in $(btrfs subvolume list -sa --sort=-rootid /); do
+	for snap in $(btrfs subvolume list -sa "${btrfssubvolsort}" /); do
 		IFS=$oldIFS
 		snap=($snap)
 		local snap_path_name=${snap[@]:13:${#snap[@]}}

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -73,10 +73,7 @@ ninit=("${GRUB_BTRFS_NINIT[@]}")
 ## Microcode(s) name(s)
 microcode=("${GRUB_BTRFS_INTEL_UCODE[@]}")
 ## Limit to show in menu
-limit=("${GRUB_BTRFS_LIMIT[@]}")
-if [ -z "$limit" ]; then
-    limit=100
-fi
+limit=("${GRUB_BTRFS_LIMIT[@]:-100}")
 
 ########################
 ### variables script ###
@@ -161,7 +158,7 @@ snapshots_entry()
 ## List of snapshots on filesystem
 snapshot_list()
 {
-	for snap in $(btrfs subvolume list -sa / | tac); do
+	for snap in $(btrfs subvolume list -sa --sort=-rootid /); do
 		IFS=$oldIFS
 		snap=($snap)
 		local snap_path_name=${snap[@]:13:${#snap[@]}}

--- a/README.md
+++ b/README.md
@@ -54,7 +54,15 @@ Add this lines to /etc/default/grub:
 
 	(Use only if you have custom intel-ucode or auto-detect failed.)
 
+* GRUB_BTRFS_LIMIT=("100")
 
+    (Limit the number of snapshots populated in the GRUB menu.)
+
+* GRUB_BTRFS_SUBVOLUME_SORT=("descending")
+
+    (Sort the found subvolumes by newest first ("descending") or oldest first
+("ascending"). If "ascending" is chosen then the $GRUB_BTRFS_LIMIT oldest
+subvolumes will populate the menu.)
 
 Generate grub.cfg (on Archlinux use grub-mkconfig -o /boot/grub/grub.cfg )
 


### PR DESCRIPTION
Allow user to limit the number of snapshots listed in GRUB. This also reverses
the order of the snapshots such that the more recent ones come first. That is,
if a user specifies GRUB_BTRFS_LIMIT=10, then only the 10 most recent snapshots
will be shown. The default limit is 100, which seems very large. The more
snapshots in the GRUB menu, the longer the system takes to boot.