### PR TITLE
Add systemd service configuration for grub updating

### DIFF
--- a/10-update_grub.conf
+++ b/10-update_grub.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPost=update-grub
+ExecStartPost=/usr/sbin/grub-mkconfig -o /boot/grub/grub.cfg

--- a/10-update_grub.conf
+++ b/10-update_grub.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPost=update-grub

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ If you would like grub to automatically update when Snapper timeline snapshots a
 - `/etc/systemd/system/snapper-timeline.service.d/`
 - `/etc/systemd/system/snapper-cleanup.service.d/`
 
+Once the configuration files are in place, `systemctl daemon-reload` should be run to reload the units and make the changes active.
+
 ##
 ### Discussion
 Pour les francophones : https://forums.archlinux.fr/viewtopic.php?f=18&t=17177

--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ Generate grub.cfg (on Arch linux use grub-mkconfig -o /boot/grub/grub.cfg )
 grub-btrfs automatically generates snapshots entries.
 
 You will see it appear differents entries (e.g : Snapshot: 2018-01-03 15:08:41  @test1 )
+##
+### Automatically update grub
+
+If you would like grub to automatically update when Snapper timeline snapshots and cleanups occur, simply install `10-update_grub.conf` in the following locations:
+
+- `/etc/systemd/system/snapper-timeline.service.d/`
+- `/etc/systemd/system/snapper-cleanup.service.d/`
 
 ##
 ### Discussion


### PR DESCRIPTION
This configuration file causes `update-grub` to be run after Snapper's cleanup and timeline services are run by systemd.

This PR resolves the first point of @darkbasic's suggestion in #23; the second point was recently resolved by #35, and the original issue itself is invalid, so I would say that this PR resolves #23. 