### PR TITLE
Optimize snapshot detection and entries generation

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -26,7 +26,7 @@
 #	(Show full path snapshot or only name in the Grub menu)														#
 # * GRUB_BTRFS_TITLE_FORMAT="p/d/n"																	#
 #	(Custom title, shows/hides p"prefix" d"date" n"name" in the Grub menu, separator "/", custom order available)							#
-# * GRUB_BTRFS_LIMIT="100"																		#
+# * GRUB_BTRFS_LIMIT="50"																		#
 #	(Limit the number of snapshots populated in the GRUB menu.)													#
 # * GRUB_BTRFS_SUBVOLUME_SORT="descending"																#
 #	(Sort the found subvolumes by newest first ("descending") or oldest first ("ascending").									#
@@ -90,7 +90,7 @@ ninit=("${GRUB_BTRFS_NINIT[@]}")
 ## Microcode(s) name(s)
 microcode=("${GRUB_BTRFS_INTEL_UCODE[@]}")
 ## Limit to show in the Grub menu
-limit_snap_show="${GRUB_BTRFS_LIMIT:-100}"
+limit_snap_show="${GRUB_BTRFS_LIMIT:-50}"
 ## How to sort snapshots list
 snap_list_sort=${GRUB_BTRFS_SUBVOLUME_SORT:-"descending"}
 case "${snap_list_sort}" in

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -281,9 +281,20 @@ snapshot_list()
 		IFS=$oldIFS
 		snap=($snap)
 		local snap_path_name=${snap[@]:13:${#snap[@]}}
+
 		# Discard deleted snapshots
 		if [ "$snap_path_name" = "DELETED" ]; then continue; fi
 		[[ ${snap_path_name%%"/"*} == "<FS_TREE>" ]] && snap_path_name=${snap_path_name#*"/"}
+
+		### ignore specific path during run "grub-mkconfig"
+		if [ ! -z "${ignore_specific_path}" ] ; then
+			for isp in ${ignore_specific_path[@]} ; do
+				[[ "${snap_path_name}" == "${isp}"/* ]] && continue 2;
+			done
+		fi
+
+		### detect if /boot directory exists
+		[[ ! -d "$gbgmp/$snap_path_name/boot" ]] && continue;
 
 		local id="${snap_path_name//[!0-9]}" # brutal way to get id: remove everything non-numeric
 		ids+=("$id")
@@ -417,14 +428,6 @@ list_kernels_initramfs()
 		snap_dir_name="$(echo "$item" | cut -d'|' -f2)"
 		snap_dir_name="$(trim "$snap_dir_name")"
 
-		### ignore specific path during run "grub-mkconfig"
-		if [ ! -z "${ignore_specific_path}" ] ; then
-			for isp in ${ignore_specific_path[@]} ; do
-				[[ "${gbgmp}"/"${snap_dir_name}" == "${gbgmp}"/"${isp}"/* ]] && continue 2;
-			done
-		fi
-		### detect if /boot directory exists
-		[[ ! -d "$gbgmp/$snap_dir_name/boot" ]] && continue;
 		### show snapshot found during run "grub-mkconfig"
 		snap_date_time="$(echo "$item" | cut -d' ' -f1-2)"
 		snap_date_time="$(trim "$snap_date_time")"

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -43,7 +43,7 @@
 #	(Use only if you have custom intel-ucode or auto-detect failed.)		    										#
 # * GRUB_BTRFS_IGNORE_SPECIFIC_PATH=("var/lib/docker" "nosnapshot")													#
 #	(Ignore specific path during run "grub-mkconfig")														#
-# * GRUB_BTRFS_CREATE_ONLY_HARMONIZED_ENTRIES="false"															#
+# * GRUB_BTRFS_CREATE_ONLY_HARMONIZED_ENTRIES="true"															#
 #	(Create entries with matching version number instead of all possible combinations of kernel and initramfs)							#
 # * GRUB_BTRFS_SNAPPER_CONFIG="root"															#
 #	(Snapper's config name to use)							#
@@ -104,7 +104,7 @@ show_total_snap_found=${GRUB_BTRFS_SHOW_TOTAL_SNAPSHOTS_FOUND:-"true"}
 ## Ignore specific path during run "grub-mkconfig"
 ignore_specific_path=("${GRUB_BTRFS_IGNORE_SPECIFIC_PATH[@]}")
 ## create only entries with harmonized version numbers
-harmonized_entries=${GRUB_BTRFS_CREATE_ONLY_HARMONIZED_ENTRIES:-"false"}
+harmonized_entries=${GRUB_BTRFS_CREATE_ONLY_HARMONIZED_ENTRIES:-"true"}
 ## snapper's config name
 snapper_config=${GRUB_BTRFS_SNAPPER_CONFIG:-"root"}
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Add this lines to /etc/default/grub:
 
 	(Use only if you have custom intel-ucode or auto-detect failed.)
 
-* GRUB_BTRFS_LIMIT="100"
+* GRUB_BTRFS_LIMIT="50"
 
 	(Limit the number of snapshots populated in the GRUB menu.)
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Add this lines to /etc/default/grub:
 
 	(Ignore specific path during run "grub-mkconfig")
 
-* GRUB_BTRFS_CREATE_ONLY_HARMONIZED_ENTRIES="false"
+* GRUB_BTRFS_CREATE_ONLY_HARMONIZED_ENTRIES="true"
 
 	(Create entries with matching version number instead of all possible combinations of kernel and initramfs, very useful with debian-like distributions)
 


### PR DESCRIPTION
1. Set default value of GRUB_BTRFS_LIMIT to 50
1. Set default value of GRUB_BTRFS_CREATE_ONLY_HARMONIZED_ENTRIES to true
1. Skip ignored snapshots during generating entries, not after

Regarding the third item, I found that the code first spends some time in `snapshot_list` generating all entries, and only afterwards is being filtered to exclude some paths. This changes the code to skip those as early as possible. Not only this improves performance a bit, but also it prettifies the output, because the entries that are being skipped cannot affect padding anymore.

References: #42 