### PR TITLE
Add a dedicated config file

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -2,68 +2,69 @@
 #
 #
 #########################################################################################################################################################################
-# Written by: Antynea																																					#
-# BTC donation address: 1Lbvz244WA8xbpHek9W2Y12cakM6rDe5Rt																												#
-# Github: https://github.com/Antynea/grub-btrfs 																														#
+# Written by: Antynea
+# BTC donation address: 1Lbvz244WA8xbpHek9W2Y12cakM6rDe5Rt
+# Github: https://github.com/Antynea/grub-btrfs
 #                                                                                                                                                                       #
-# Purpose: Include btrfs snapshots at boot options (grub-menu).																											#
-#																																										#
-# What this script does:																																				#
-# Simple rollback using snapshots you made previously.																													#
-# - Automatically List snapshots existing on root partition (btrfs).																									#
-# - Automatically Detect if "/boot" is in separate partition.																											#
-# - Automatically Detect kernel, initramfs and intel microcode in "/boot" directory on snapshots.                               										#
-# - Automatically Create corresponding "menuentry" in grub.cfg , which ensures a very easy rollback.																	#
-# - Automatically detect snapper and use snapper's snapshot description if available.																					#
-#																																										#
-# How to customize it:																																					#
-# - Add this lines to /etc/default/grub:																																#
-#																																										#
-# * GRUB_BTRFS_SUBMENUNAME="Arch Linux snapshots" 																														#
-#		(Name appearing in the Grub menu.)																																#
-# * GRUB_BTRFS_PREFIXENTRY="Snapshot:"        		   																													#
-#		(Add a name ahead your snapshots entries in the Grub menu.) 																									#
-# * GRUB_BTRFS_DISPLAY_PATH_SNAPSHOT="true"																																#
-#		(Show full path snapshot or only name in the Grub menu)																											#
-# * GRUB_BTRFS_TITLE_FORMAT="p/d/n"																																		#
-#		(Custom title, shows/hides p"prefix" d"date" n"name" in the Grub menu, separator "/", custom order available)													#
-# * GRUB_BTRFS_LIMIT="50"																																				#
-#		(Limit the number of snapshots populated in the GRUB menu.)																										#
-# * GRUB_BTRFS_SUBVOLUME_SORT="descending"																																#
-#		(Sort the found subvolumes by newest first ("descending") or oldest first ("ascending").																		#
-#		If "ascending" is chosen then the $GRUB_BTRFS_LIMIT oldest subvolumes will populate the menu.)																	#
-# * GRUB_BTRFS_SHOW_SNAPSHOTS_FOUND="true"																																#
-#		(Show snapshots found during run "grub-mkconfig")																												#
-# * GRUB_BTRFS_SHOW_TOTAL_SNAPSHOTS_FOUND="true"																														#
-#		(Show Total of snapshots found during run "grub-mkconfig")																										#
-# * GRUB_BTRFS_NKERNEL=("vmlinuz-linux") 		 																														#
-#		(Use only if you have custom kernel name.)			                        																					#
-# * GRUB_BTRFS_NINIT=("initramfs-linux.img" "initramfs-linux-fallback.img")																								#
-#		(Use only if you have custom initramfs name.)						                      																		#
-# * GRUB_BTRFS_INTEL_UCODE=("intel-ucode.img") 																															#
-#		(Use only if you have custom intel-ucode.)		    			                          																		#
-# * GRUB_BTRFS_IGNORE_SPECIFIC_PATH=("var/lib/docker")					             																					#
-#		(Ignore specific path during run "grub-mkconfig")																												#
-# * GRUB_BTRFS_SNAPPER_CONFIG="root"																																	#
-#		(Snapper's config name to use)																																	#
-# * GRUB_BTRFS_DISABLE="false"																																			#
-#		Disable Grub-btrfs (default=active)																																#
-#																																										#
-# - Generate grub.cfg (on Arch Linux use grub-mkconfig -o /boot/grub/grub.cfg)																							#
-#																																										#
-# - grub-btrfs automatically generates snapshots entries.																												#
-# - You will see it appear different entries (e.g : Snapshot: [2014-02-12 11:24:37] my snapshot name overkill)															#
-#																																										#
-# Automatically update grub																																				#
-#  If you would like grub to automatically update when Snapper timeline snapshots and cleanups occur, simply install 10-update_grub.conf in the following locations:	#
-# - /etc/systemd/system/snapper-timeline.service.d/																														#
-# - /etc/systemd/system/snapper-cleanup.service.d/																														#
-# Once the configuration files are in place, systemctl daemon-reload should be run to reload the units and make the changes active.										#
-#																																										#
-# Special thanks for assistance and contributions:																														#
-# - My friends																																							#
-# - All contributors on Github																																			#
-#																																										#
+# Purpose: Include btrfs snapshots at boot options (grub-menu).
+#
+# What this script does:
+# Simple rollback using snapshots you made previously.
+# - Automatically List snapshots existing on root partition (btrfs).
+# - Automatically Detect if "/boot" is in separate partition.
+# - Automatically Detect kernel, initramfs and intel microcode in "/boot" directory on snapshots.
+# - Automatically Create corresponding "menuentry" in grub.cfg , which ensures a very easy rollback.
+# - Automatically detect snapper and use snapper's snapshot description if available.
+#
+# How to customize it:
+# - Add this lines to /etc/default/grub:
+# Add these lines to /etc/default/grub or /etc/grub.d/41_snapshots-btrfs_config:
+#
+# * GRUB_BTRFS_SUBMENUNAME="Arch Linux snapshots"
+#		(Name appearing in the Grub menu.)
+# * GRUB_BTRFS_PREFIXENTRY="Snapshot:"
+#		(Add a name ahead your snapshots entries in the Grub menu.)
+# * GRUB_BTRFS_DISPLAY_PATH_SNAPSHOT="true"
+#		(Show full path snapshot or only name in the Grub menu)
+# * GRUB_BTRFS_TITLE_FORMAT="p/d/n"
+#		(Custom title, shows/hides p"prefix" d"date" n"name" in the Grub menu, separator "/", custom order available)
+# * GRUB_BTRFS_LIMIT="50"
+#		(Limit the number of snapshots populated in the GRUB menu.)
+# * GRUB_BTRFS_SUBVOLUME_SORT="descending"
+#		(Sort the found subvolumes by newest first ("descending") or oldest first ("ascending").
+#		If "ascending" is chosen then the $GRUB_BTRFS_LIMIT oldest subvolumes will populate the menu.)
+# * GRUB_BTRFS_SHOW_SNAPSHOTS_FOUND="true"
+#		(Show snapshots found during run "grub-mkconfig")
+# * GRUB_BTRFS_SHOW_TOTAL_SNAPSHOTS_FOUND="true"
+#		(Show Total of snapshots found during run "grub-mkconfig")
+# * GRUB_BTRFS_NKERNEL=("vmlinuz-linux")
+#		(Use only if you have custom kernel name.)
+# * GRUB_BTRFS_NINIT=("initramfs-linux.img" "initramfs-linux-fallback.img")
+#		(Use only if you have custom initramfs name.)
+# * GRUB_BTRFS_INTEL_UCODE=("intel-ucode.img")
+#		(Use only if you have custom intel-ucode.)
+# * GRUB_BTRFS_IGNORE_SPECIFIC_PATH=("var/lib/docker")
+#		(Ignore specific path during run "grub-mkconfig")
+# * GRUB_BTRFS_SNAPPER_CONFIG="root"
+#		(Snapper's config name to use)
+# * GRUB_BTRFS_DISABLE="false"
+#		Disable Grub-btrfs (default=active)
+#
+# - Generate grub.cfg (on Arch Linux use grub-mkconfig -o /boot/grub/grub.cfg)
+#
+# - grub-btrfs automatically generates snapshots entries.
+# - You will see it appear different entries (e.g : Snapshot: [2014-02-12 11:24:37] my snapshot name overkill)
+#
+# Automatically update grub
+#  If you would like grub to automatically update when Snapper timeline snapshots and cleanups occur, simply install 10-update_grub.conf in the following locations:
+# - /etc/systemd/system/snapper-timeline.service.d/
+# - /etc/systemd/system/snapper-cleanup.service.d/
+# Once the configuration files are in place, systemctl daemon-reload should be run to reload the units and make the changes active.
+#
+# Special thanks for assistance and contributions:
+# - My friends
+# - All contributors on Github
+#
 #########################################################################################################################################################################
 
 set -e
@@ -421,7 +422,7 @@ boot_bounded()
 		snap_dir_name="$(trim "$snap_dir_name")"
 		snap_date_time="$(echo "$item" | cut -d' ' -f1-2)"
 		snap_date_time="$(trim "$snap_date_time")"
-		
+
 		boot_dir="$gbgmp/$snap_dir_name/boot"
 		# Kernel (Original + custom kernel)
 		detect_kernel
@@ -464,12 +465,12 @@ boot_separate()
 	detect_kernel
 	if [ -z "${list_kernel}" ]; then print_error "Kernels not found."; fi
 	name_kernel=("${list_kernel[@]##*"/"}")
-	
+
 	# Initramfs (Original + custom initramfs)
 	detect_initramfs
 	if [ -z "${list_initramfs}" ]; then print_error "Initramfs not found."; fi
 	name_initramfs=("${list_initramfs[@]##*"/"}")
-	
+
 	# microcode (auto-detect + custom microcode)
 	detect_microcode
 	name_microcode=("${list_ucode[@]##*"/"}")

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -73,8 +73,10 @@ prefix="/usr"
 exec_prefix="/usr"
 datarootdir="/usr/share"
 sysconfdir="/etc"
+grub_btrfs_config="${sysconfdir}/grub.d/41_snapshots-btrfs_config"
 
 . "${sysconfdir}/default/grub"
+[[ -f "$grub_btrfs_config" ]] && . "$grub_btrfs_config"
 . "$datarootdir/grub/grub-mkconfig_lib"
 
 ######################################

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -17,38 +17,8 @@
 # - Automatically detect snapper and use snapper's snapshot description if available.
 #
 # How to customize it:
-# - Add this lines to /etc/default/grub:
-# Add these lines to /etc/default/grub or /etc/grub.d/41_snapshots-btrfs_config:
-#
-# * GRUB_BTRFS_SUBMENUNAME="Arch Linux snapshots"
-#		(Name appearing in the Grub menu.)
-# * GRUB_BTRFS_PREFIXENTRY="Snapshot:"
-#		(Add a name ahead your snapshots entries in the Grub menu.)
-# * GRUB_BTRFS_DISPLAY_PATH_SNAPSHOT="true"
-#		(Show full path snapshot or only name in the Grub menu)
-# * GRUB_BTRFS_TITLE_FORMAT="p/d/n"
-#		(Custom title, shows/hides p"prefix" d"date" n"name" in the Grub menu, separator "/", custom order available)
-# * GRUB_BTRFS_LIMIT="50"
-#		(Limit the number of snapshots populated in the GRUB menu.)
-# * GRUB_BTRFS_SUBVOLUME_SORT="descending"
-#		(Sort the found subvolumes by newest first ("descending") or oldest first ("ascending").
-#		If "ascending" is chosen then the $GRUB_BTRFS_LIMIT oldest subvolumes will populate the menu.)
-# * GRUB_BTRFS_SHOW_SNAPSHOTS_FOUND="true"
-#		(Show snapshots found during run "grub-mkconfig")
-# * GRUB_BTRFS_SHOW_TOTAL_SNAPSHOTS_FOUND="true"
-#		(Show Total of snapshots found during run "grub-mkconfig")
-# * GRUB_BTRFS_NKERNEL=("vmlinuz-linux")
-#		(Use only if you have custom kernel name.)
-# * GRUB_BTRFS_NINIT=("initramfs-linux.img" "initramfs-linux-fallback.img")
-#		(Use only if you have custom initramfs name.)
-# * GRUB_BTRFS_INTEL_UCODE=("intel-ucode.img")
-#		(Use only if you have custom intel-ucode.)
-# * GRUB_BTRFS_IGNORE_SPECIFIC_PATH=("var/lib/docker")
-#		(Ignore specific path during run "grub-mkconfig")
-# * GRUB_BTRFS_SNAPPER_CONFIG="root"
-#		(Snapper's config name to use)
-# * GRUB_BTRFS_DISABLE="false"
-#		Disable Grub-btrfs (default=active)
+# - Refer 41_snapshots-btrfs_config for the list of available options and their default values.
+# - Place your configurations to either /etc/grub.d/41_snapshots-btrfs_config or /etc/default/grub.
 #
 # - Generate grub.cfg (on Arch Linux use grub-mkconfig -o /boot/grub/grub.cfg)
 #

--- a/41_snapshots-btrfs_config
+++ b/41_snapshots-btrfs_config
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# GRUB_BTRFS_SUBMENUNAME="Arch Linux snapshots"                              # Name appearing in the Grub menu
+# GRUB_BTRFS_PREFIXENTRY="Snapshot:"                                         # Add a name ahead your snapshots entries in the Grub menu
+# GRUB_BTRFS_DISPLAY_PATH_SNAPSHOT="true"                                    # Show full path snapshot or only name in the Grub menu
+# GRUB_BTRFS_TITLE_FORMAT="p/d/n"                                            # Custom title, shows/hides p"prefix" d"date" n"name" in the Grub menu, separator "/", custom order available
+# GRUB_BTRFS_LIMIT="50"                                                      # Limit the number of snapshots populated in the GRUB menu
+# GRUB_BTRFS_SUBVOLUME_SORT="descending"                                     # Sort the found subvolumes by newest first ("descending") or oldest first ("ascending") and show $GRUB_BTRFS_LIMIT first entries.
+# GRUB_BTRFS_SHOW_SNAPSHOTS_FOUND="true"                                     # Show snapshots found during run "grub-mkconfig"
+# GRUB_BTRFS_SHOW_TOTAL_SNAPSHOTS_FOUND="true"                               # Show Total of snapshots found during run "grub-mkconfig"
+# GRUB_BTRFS_NKERNEL=("vmlinuz-linux")                                       # Use only if you have custom kernel name
+# GRUB_BTRFS_NINIT=("initramfs-linux.img" "initramfs-linux-fallback.img")    # Use only if you have custom initramfs name
+# GRUB_BTRFS_INTEL_UCODE=("intel-ucode.img")                                 # Use only if you have custom intel-ucode
+# GRUB_BTRFS_IGNORE_SPECIFIC_PATH=("var/lib/docker")                         # Ignore specific path during run "grub-mkconfig"
+# GRUB_BTRFS_SNAPPER_CONFIG="root"                                           # Snapper's config name to use
+# GRUB_BTRFS_DISABLE="false"                                                 # Disable Grub-btrfs


### PR DESCRIPTION
I don't entirely like that this script is reusing `/etc/defaut/grub` file, I want to have a separate config file with only `grub-btrfs` configs and nothing else (so that I can put it in my dotfiles github repo).

@Antynea:

- 090f002 removes the "#" character in the comments, my vim goes crazy when it sees lots of tabs and then "#" character in the end. Do you agree to not have the trailing "#"?
- ff0f76f shows the actual difference, if the file exists, we source it - nothing magical.
- 382e543 here I decided to extract the default config from the comments of `41_snapshots-btrfs` to a separate file `41_snapshots-btrfs_config`. The beauty of this is that a user can simply copy-paste this file in `/etc/grub.d/` and uncomment those lines that they care about.