### PR TITLE
Add systemd.path as option to monitor for new Snapshots

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -20,7 +20,7 @@
 # - Refer 41_snapshots-btrfs_config for the list of available options and their default values.
 # - Place your configurations to either /etc/grub.d/41_snapshots-btrfs_config or /etc/default/grub.
 #
-# - Generate grub.cfg (on Arch Linux use grub-mkconfig -o /boot/grub/grub.cfg)
+# - Generate grub.cfg (on Arch Linux use grub-mkconfig -o /boot/$grub_directory/grub.cfg)
 #
 # - grub-btrfs automatically generates snapshots entries.
 # - You will see it appear different entries (e.g : Snapshot: [2014-02-12 11:24:37] my snapshot name overkill)
@@ -86,6 +86,8 @@ ignore_specific_path=("${GRUB_BTRFS_IGNORE_SPECIFIC_PATH[@]}")
 ## snapper's config name
 snapper_config=${GRUB_BTRFS_SNAPPER_CONFIG:-"root"}
 
+grub_directory=${GRUB_BTRFS_DIRNAME:-"grub"}
+
 ########################
 ### variables script ###
 ########################
@@ -147,10 +149,10 @@ test_btrfs()
 
 ## Create entry
 entry()	{
-echo "$@" >> "/boot/grub/grub-btrfs.cfg"
+echo "$@" >> "/boot/$grub_directory/grub-btrfs.cfg"
 # local arg="$@"
-# echo "${arg}" >> "/boot/grub/grub-btrfs.cfg"
-# cat << EOF >> "/boot/grub/grub-btrfs.cfg"
+# echo "${arg}" >> "/boot/$grub_directory/grub-btrfs.cfg"
+# cat << EOF >> "/boot/$grub_directory/grub-btrfs.cfg"
 # ${arg}
 # EOF
 }
@@ -492,8 +494,8 @@ printf "###### - Grub-btrfs: Snapshot detection started - ######\n" >&2 ;
 # if btrfs prog isn't installed, exit
 test_btrfs
 # Delete existing config
-#rm -f --preserve-root "/boot/grub/grub-btrfs.cfg"
-> "/boot/grub/grub-btrfs.cfg"
+#rm -f --preserve-root "/boot/$grub_directory/grub-btrfs.cfg"
+> "/boot/$grub_directory/grub-btrfs.cfg"
 # Create mount point then mounting
 [[ ! -d $gbgmp ]] && mkdir -p $gbgmp
 mount -o subvolid=5 /dev/disk/by-uuid/$root_uuid $gbgmp/
@@ -524,7 +526,7 @@ fi
 if [[ "${count_limit_snap}" = "0" || -z "${count_limit_snap}" ]]; then
 	print_error "No snapshots found."
 fi
-root_grub="$(make_system_path_relative_to_its_root /boot/grub)"
+root_grub="$(make_system_path_relative_to_its_root /boot/$grub_directory)"
 # Make a submenu in GRUB (grub.cfg)
 cat << EOF
 submenu '${submenuname}' {

--- a/41_snapshots-btrfs_config
+++ b/41_snapshots-btrfs_config
@@ -14,3 +14,4 @@
 # GRUB_BTRFS_IGNORE_SPECIFIC_PATH=("var/lib/docker")                         # Ignore specific path during run "grub-mkconfig"
 # GRUB_BTRFS_SNAPPER_CONFIG="root"                                           # Snapper's config name to use
 # GRUB_BTRFS_DISABLE="false"                                                 # Disable Grub-btrfs
+# GRUB_BTRFS_DIRNAME=grub							     # Might be grub2 on some systems ex. /boot/grub2/...

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Add this lines to /etc/default/grub:
 
 	(Disable grub-btrfs)
 
+* GRUB_BTRFS_DIRNAME="grub"
+
+	(Name of the grub folder on /boot/)
+
 
 Generate grub.cfg (on Arch linux use grub-mkconfig -o /boot/grub/grub.cfg )
 
@@ -99,6 +103,8 @@ If you would like grub to automatically update when Snapper timeline snapshots a
 
 - `/etc/systemd/system/snapper-timeline.service.d/`
 - `/etc/systemd/system/snapper-cleanup.service.d/`
+
+Or copy `grub-btrfs.path` and `grub-btrfs.service` to `/etc/systemd/system/`
 
 Once the configuration files are in place, `systemctl daemon-reload` should be run to reload the units and make the changes active.
 

--- a/grub-btrfs.path
+++ b/grub-btrfs.path
@@ -1,0 +1,8 @@
+[Unit]
+Description=Monitors for new snapshots
+
+[Path]
+PathModified=/.snapshots
+
+[Install]
+WantedBy=multi-user.target

--- a/grub-btrfs.service
+++ b/grub-btrfs.service
@@ -4,6 +4,7 @@ Description=Regenerate grub-btrfs.cfg
 [Service]
 Type=oneshot
 #Inital setup
-ExecStartPre=-/bin/bash -c '[ ! -f "/boot/grub/grub-btrfs.cfg" ] && grub2-mkconfig -o /boot/grub/grub.cfg'
+EnvironmentFile=/etc/grub.d/41_snapshots-btrfs_config
+ExecStartPre=-/bin/bash -c '[ ! -f "/boot/${GRUB_BTRFS_DIRNAME:-grub}/grub-btrfs.cfg" ] && grub2-mkconfig -o /boot/${GRUB_BTRFS_DIRNAME:-grub}/grub.cfg'
 #Regenerate grub-btrfs.cfg instead of the whole grub menu
 ExecStart=/etc/grub.d/41_snapshots-btrfs

--- a/grub-btrfs.service
+++ b/grub-btrfs.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Regenerate grub-btrfs.cfg
+
+[Service]
+Type=oneshot
+#Inital setup
+ExecStartPre=-/bin/bash -c '[ ! -f "/boot/grub/grub-btrfs.cfg" ] && grub2-mkconfig -o /boot/grub/grub.cfg'
+#Regenerate grub-btrfs.cfg instead of the whole grub menu
+ExecStart=/etc/grub.d/41_snapshots-btrfs


### PR DESCRIPTION
Added two scripts to monitor for new Snapshots, the advantage being that these also capture manual snapshots whereas the previous ones only responded to snapshots created by cron. Also added another option to support other names for /boot/grub (under fedora i.e. it's /boot/grub2). 