### PR TITLE
Make 'grub-mkconfig' command name configurable

### DIFF
--- a/10-update_grub.conf
+++ b/10-update_grub.conf
@@ -1,2 +1,7 @@
 [Service]
-ExecStartPost=/usr/sbin/grub-mkconfig -o /boot/grub/grub.cfg
+# Set the possible paths for `grub-mkconfig`
+Environment="PATH=/sbin:/bin:/usr/sbin:/usr/bin"
+# Load environment variables from the configuration
+EnvironmentFile=/etc/grub.d/41_snapshots-btrfs_config
+# Regenerate just '/boot/grub/grub-btrfs.cfg' if it exists, else regenerate the whole grub menu
+ExecStartPost=/bin/bash -c 'if [ -s "/boot/${GRUB_BTRFS_DIRNAME:-grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else ${GRUB_BTRFS_MKCONFIG:-/usr/bin/grub-mkconfig} -o /boot/${GRUB_BTRFS_DIRNAME:-grub}/grub.cfg; fi'

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -5,7 +5,7 @@
 # Written by: Antynea
 # BTC donation address: 1Lbvz244WA8xbpHek9W2Y12cakM6rDe5Rt
 # Github: https://github.com/Antynea/grub-btrfs
-#                                                                                                                                                                       
+#
 # Purpose: Include btrfs snapshots at boot options (grub-menu).
 #
 # What this script does:
@@ -96,14 +96,20 @@ grub_directory=${GRUB_BTRFS_DIRNAME:-"grub"}
 ## Internationalization (default : english)
 export TEXTDOMAIN=grub-btrfs-git
 export TEXTDOMAINDIR="/usr/share/locale"
-## hints string
-hs_boot=$(${grub_probe} --target="hints_string" "/boot" 2>/dev/null)
-## UUID of the boot partition
-boot_uuid=$(${grub_probe} --target="fs_uuid" "/boot" 2>/dev/null)
-## Type filesystem of boot partition
+## Probe info "Boot partition"
+# Boot device
+boot_device=$(${grub_probe} --target=device "/boot")
+# hints string
+boot_hs=$(${grub_probe} --device "${boot_device}" --target="hints_string" 2>/dev/null)
+# UUID of the boot partition
+boot_uuid=$(${grub_probe} --device "${boot_device}" --target="fs_uuid" 2>/dev/null)
+# Type filesystem of boot partition
 boot_fs=$(${grub_probe} --target="fs" "/boot" 2>/dev/null)
-## UUID of the root partition
-root_uuid=$(${grub_probe} "/" --target="fs_uuid" 2>/dev/null)
+## Probe info "Root partition"
+# Root device
+root_device=$(${grub_probe} --target=device "/")
+# UUID of the root partition
+root_uuid=$(${grub_probe} --device "${root_device}" --target="fs_uuid" 2>/dev/null)
 ## Parameters passed to the kernel
 kernel_parameters="$GRUB_CMDLINE_LINUX $GRUB_CMDLINE_LINUX_DEFAULT"
 ## Mount point location
@@ -114,12 +120,12 @@ CLASS="--class snapshots --class gnu-linux --class gnu --class os"
 oldIFS=$IFS
 ## Detect uuid requirement (lvm,btrfs...)
 check_uuid_required() {
-if [ "x${GRUB_DEVICE_UUID}" = "x" ] || [ "x${GRUB_DISABLE_LINUX_UUID}" = "xtrue" ] \
-    || ! test -e "/dev/disk/by-uuid/${GRUB_DEVICE_UUID}" \
-    || ( test -e "${GRUB_DEVICE}" && uses_abstraction "${GRUB_DEVICE}" lvm ); then
-  LINUX_ROOT_DEVICE=${GRUB_DEVICE}
+if [ "x${root_uuid}" = "x" ] || [ "x${GRUB_DISABLE_LINUX_UUID}" = "xtrue" ] \
+    || ! test -e "/dev/disk/by-uuid/${root_uuid}" \
+    || ( test -e "${root_device}" && uses_abstraction "${root_device}" lvm ); then
+  LINUX_ROOT_DEVICE=${root_device}
 else
-  LINUX_ROOT_DEVICE=UUID=${GRUB_DEVICE_UUID}
+  LINUX_ROOT_DEVICE=UUID=${root_uuid}
 fi
 }
 
@@ -193,7 +199,7 @@ make_menu_entries()
 		set gfxpayload=keep
 		insmod ${boot_fs}
 		if [ x\$feature_platform_search_hint = xy ]; then
-			search --no-floppy --fs-uuid  --set=root ${hs_boot} ${boot_uuid}
+			search --no-floppy --fs-uuid  --set=root ${boot_hs} ${boot_uuid}
 		else
 			search --no-floppy --fs-uuid  --set=root ${boot_uuid}
 		fi

--- a/41_snapshots-btrfs_config
+++ b/41_snapshots-btrfs_config
@@ -14,5 +14,6 @@
 # GRUB_BTRFS_IGNORE_SPECIFIC_PATH=("var/lib/docker")                         # Ignore specific path during run "grub-mkconfig"
 # GRUB_BTRFS_SNAPPER_CONFIG="root"                                           # Snapper's config name to use
 # GRUB_BTRFS_DISABLE="false"                                                 # Disable Grub-btrfs
-# GRUB_BTRFS_DIRNAME=grub		                                     # Might be grub2 on some systems ex. /boot/grub2/...
+# GRUB_BTRFS_DIRNAME=grub                                                    # Might be grub2 on some systems ex. /boot/grub2/...
 # GRUB_BTRFS_OVERRIDE_BOOT_PARTITION_DETECTION="false"                       # Change to "true" if you have a boot partition in a different subvolume
+# GRUB_BTRFS_MKCONFIG=grub-mkconfig                                          # Might be 'grub2-mkconfig' on some systems

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Add this lines to /etc/default/grub:
 * GRUB_BTRFS_OVERRIDE_BOOT_PARTITION_DETECTION="false"
 	(Change to "true" if you have a boot partition in a different subvolume)
 
+* GRUB_BTRFS_MKCONFIG=grub-mkconfig
+
+    (Name or path of the 'grub-mkconfig' executable; this is 'grub2-mkconfig' on some systems)
+
 Generate grub.cfg (on Arch linux use grub-mkconfig -o /boot/grub/grub.cfg )
 
 grub-btrfs automatically generates snapshots entries.

--- a/grub-btrfs.service
+++ b/grub-btrfs.service
@@ -3,8 +3,9 @@ Description=Regenerate grub-btrfs.cfg
 
 [Service]
 Type=oneshot
-#Inital setup
+# Set the possible paths for `grub-mkconfig`
+Environment="PATH=/sbin:/bin:/usr/sbin:/usr/bin"
+# Load environment variables from the configuration
 EnvironmentFile=/etc/grub.d/41_snapshots-btrfs_config
-ExecStartPre=-/bin/bash -c '[ ! -f "/boot/${GRUB_BTRFS_DIRNAME:-grub}/grub-btrfs.cfg" ] && grub2-mkconfig -o /boot/${GRUB_BTRFS_DIRNAME:-grub}/grub.cfg'
-#Regenerate grub-btrfs.cfg instead of the whole grub menu
-ExecStart=/etc/grub.d/41_snapshots-btrfs
+# Regenerate just '/boot/grub/grub-btrfs.cfg' if it exists and is not empty, else regenerate the whole grub menu
+ExecStart=/bin/bash -c 'if [ -s "/boot/${GRUB_BTRFS_DIRNAME:-grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else ${GRUB_BTRFS_MKCONFIG:-/usr/bin/grub-mkconfig} -o /boot/${GRUB_BTRFS_DIRNAME:-grub}/grub.cfg; fi'


### PR DESCRIPTION
I noticed that `grub-btrfs.service` was using `grub2-mkconfig` which is not available on my system (Manjaro), so I've rewritten the service to allow the command name to be a configuration option. I've set `grub-mkconfig` as the default, since that's the command name that I've encountered most often in recent years, but I'm happy to change it if you would like.

I found the pair of commands used in `grub-btrfs.service` quite unclear, and on the first run (or whenever `grub-btrfs.cfg` doesn't exist), both commands would be run and the configuration would be regenerated twice. To resolve this, I've combined the commands into a single `if... else...` statement.

I've also updated `10-update_grub.conf` to use the configurable grub directory name and to use the improved command from `grub-btrfs.service`.

As a side note, I'm not sure how useful it is to retain `10-update_grub.conf` given that the new `grub-btrfs.*` services provide a more general solution. The former works only when the systemd services are used, while the latter works for systemd, cron, and manual snapshots.