### PR TITLE
Support snapper 0.7.1

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -237,8 +237,8 @@ snapshot_list()
 	# Query info from snapper if it is installed
 	type snapper >/dev/null 2>&1
 	if [[ $? -eq 0 ]]; then
-		local snapper_ids=($(snapper -t 0 -c "$snapper_config" list | tail -n +3 | cut -d'|' -f 2))
-		local snapper_types=($(snapper -t 0 -c "$snapper_config" list | tail -n +3 | cut -d'|' -f 1))
+		local snapper_ids=($(snapper -t 0 -c "$snapper_config" list | tail -n +3 | cut -d'|' -f 1))
+		local snapper_types=($(snapper -t 0 -c "$snapper_config" list | tail -n +3 | cut -d'|' -f 2))
 
 		IFS=$'\n'
 		local snapper_descriptions=($(snapper -t 0 -c "$snapper_config" list | tail -n +3 | cut -d'|' -f 7))


### PR DESCRIPTION
Snapper changed the order of columns, ID now comes before type.

@Antynea it would be nice to publish a new version of grub-btrfs soon, because people who've already upgraded snapper suddenly lost descriptions on their snapshots.