### PR TITLE
fix get description when quota enabled

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -243,7 +243,7 @@ snapshot_list()
 		local snapper_types=($(snapper -t 0 -c "$snapper_config" list | tail -n +3 | cut -d'|' -f 2))
 
 		IFS=$'\n'
-		local snapper_descriptions=($(snapper -t 0 -c "$snapper_config" list | tail -n +3 | cut -d'|' -f 7))
+		local snapper_descriptions=($(snapper -t 0 -c "$snapper_config" list | tail -n +3 | rev | cut -d'|' -f 2 | rev))
 	fi
 
 	IFS=$'\n'


### PR DESCRIPTION
When quota is enabled like this:
sudo btrfs quota enable /
the snapper list will contain an additional column (6.) with the size of the snapshot.
Because of this, we have to get the description from the end of the line.