### PR TITLE
add --no-dbus option to snapper list

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -239,11 +239,11 @@ snapshot_list()
 	# Query info from snapper if it is installed
 	type snapper >/dev/null 2>&1
 	if [[ $? -eq 0 ]]; then
-		local snapper_ids=($(snapper -t 0 -c "$snapper_config" list | tail -n +3 | cut -d'|' -f 1))
-		local snapper_types=($(snapper -t 0 -c "$snapper_config" list | tail -n +3 | cut -d'|' -f 2))
+		local snapper_ids=($(snapper --no-dbus -t 0 -c "$snapper_config" list | tail -n +3 | cut -d'|' -f 1))
+		local snapper_types=($(snapper --no-dbus -t 0 -c "$snapper_config" list | tail -n +3 | cut -d'|' -f 2))
 
 		IFS=$'\n'
-		local snapper_descriptions=($(snapper -t 0 -c "$snapper_config" list | tail -n +3 | rev | cut -d'|' -f 2 | rev))
+		local snapper_descriptions=($(snapper --no-dbus -t 0 -c "$snapper_config" list | tail -n +3 | rev | cut -d'|' -f 2 | rev))
 	fi
 
 	IFS=$'\n'


### PR DESCRIPTION
For the read only snapper commands, we can use the --no-dbus option. With dbus, snapper can notify the daemon on certain actions. For reading the snapshots, it is not needed.
In a chroot-ed environment, it is necessary to run snapper without dbus.
see: https://github.com/wesbarnett/snap-pac/issues/23