### PR TITLE
remove non numeric characters from snapshot id

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -300,6 +300,10 @@ snapshot_list()
 		local entry="${entries[$i]}"
 		for j in "${!snapper_ids[@]}"; do
 			local snapper_id="${snapper_ids[$j]//[[:space:]]/}"
+			# remove other non numeric characters
+			snapper_id="${snapper_id//\*/}"
+			snapper_id="${snapper_id//\+/}"
+			snapper_id="${snapper_id//-/}"
 			if [[ "$snapper_id" == "$id" ]]; then
 				local snapper_type=$(trim "${snapper_types[$j]}")
 				local snapper_description=$(trim "${snapper_descriptions[$j]}")


### PR DESCRIPTION
Snapper list will indicate if the snapshot is the current, or default, or both.
It will add an additional character to the id, like this:
{number}+ default subvolume
{number}- currently running snapshot
{number}* currently running default subvolume
This will confuse grub-btrfs, and we will loose the description for that snapshot.
This patch will remove those extra characters from the id.