### PR TITLE
Fixed incorrect path to the grub-btrfs.cfg file in Grub menu

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -549,8 +549,7 @@ root_grub="$(make_system_path_relative_to_its_root /boot/$grub_directory)"
 # Make a submenu in GRUB (grub.cfg)
 cat << EOF
 submenu '${submenuname}' {
-	search -f --set=root --no-floppy /grub/grub-btrfs.cfg
-	configfile "${root_grub}/grub-btrfs.cfg"
+	configfile "\${prefix}/grub-btrfs.cfg"
 }
 EOF
 printf "###### - Grub-btrfs: Snapshot detection ended   - ######\n" >&2 ;


### PR DESCRIPTION
Fix #72 
The submenu generated by "grub-btrfs" doesn't load in the "GRUB menu."
Sometimes the Grub prefix and root variable don't match.
This ensures that the prefix variable is used to load the grub-btrfs.cfg file.
See
[How to specify files](https://www.gnu.org/software/grub/manual/grub/html_node/File-name-syntax.html#File-name-syntax)
and
[Special environment variables : root](https://www.gnu.org/software/grub/manual/grub/html_node/root.html#root)
and 
[Special environment variables : prefix](https://www.gnu.org/software/grub/manual/grub/html_node/prefix.html#prefix)