### PR TITLE
Add password protection support for the submenu

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -92,6 +92,18 @@ snapper_config=${GRUB_BTRFS_SNAPPER_CONFIG:-"root"}
 override_boot_partition_detection=${GRUB_BTRFS_OVERRIDE_BOOT_PARTITION_DETECTION:-"false"}
 ## Customize GRUB directory
 grub_directory=${GRUB_BTRFS_DIRNAME:-"grub"}
+## Password protection management for submenu
+# Protection support for submenu (--unrestricted)
+unrestricted_access_submenu=${GRUB_BTRFS_DISABLE_PROTECTION_SUBMENU:-"false"}
+case "${unrestricted_access_submenu}" in
+	true)	unrestricted_access_submenu="--unrestricted ";;
+	*)		unrestricted_access_submenu=""
+esac
+# Authorized users (--users foo,bar)
+protection_authorized_users=${GRUB_BTRFS_PROTECTION_AUTHORIZED_USERS}
+if [ ! -z "${protection_authorized_users}" ] ; then
+	protection_authorized_users="--users ${GRUB_BTRFS_PROTECTION_AUTHORIZED_USERS} "
+fi
 
 ########################
 ### variables script ###
@@ -191,10 +203,10 @@ make_menu_entries()
 			for u in "${name_microcode[@]}"; do
 				if [[ -f "${boot_dir}"/"${u}" && "${i}" != "${prefix_i}-${kversion}-${alt_suffix_i}" ]] ; then
 				entry "
-	menuentry '"${k}" & "${i}" & "${u}"' ${CLASS} "\$menuentry_id_option" 'gnulinux-snapshots-$boot_uuid'{"
+	menuentry '"${k}" & "${i}" & "${u}"' ${CLASS} "\$menuentry_id_option" 'gnulinux-snapshots-$boot_uuid' {"
 				else
 				entry "
-	menuentry '"${k}" & "${i}"' ${CLASS} "\$menuentry_id_option" 'gnulinux-snapshots-$boot_uuid'{"
+	menuentry '"${k}" & "${i}"' ${CLASS} "\$menuentry_id_option" 'gnulinux-snapshots-$boot_uuid' {"
 				fi
 				entry "\
 		if [ x\$feature_all_video_module = xy ]; then
@@ -555,7 +567,7 @@ fi
 root_grub="$(make_system_path_relative_to_its_root /boot/$grub_directory)"
 # Make a submenu in GRUB (grub.cfg)
 cat << EOF
-submenu '${submenuname}' {
+submenu '${submenuname}' ${protection_authorized_users}${unrestricted_access_submenu}{
 	configfile "\${prefix}/grub-btrfs.cfg"
 }
 EOF

--- a/README.md
+++ b/README.md
@@ -136,6 +136,20 @@ You have the possibility to modify many parameters in `/etc/default/grub-btrfs/c
 
 	Name or path of the 'grub-mkconfig' executable; might be 'grub2-mkconfig' on some distributions.
 	
+- Password protection management for submenu (refer to the [Grub documentation](https://www.gnu.org/software/grub/manual/grub/grub.html#Authentication-and-authorisation))
+
+	- GRUB_BTRFS_PROTECTION_AUTHORIZED_USERS=""
+
+		Add authorized usernames separate by comma (foo,bar)
+	
+		When Grub's password protection is enabled, the superuser is authorized by default, it isn't necessary to add it
+		
+	- GRUB_BTRFS_DISABLE_PROTECTION_SUBMENU="false"
+
+		Disable authentication support for submenu of Grub-btrfs only (--unrestricted)
+	
+		doesn't work if `GRUB_BTRFS_PROTECTION_AUTHORIZED_USERS` isn't empty
+
 ##
 ### Automatically update grub
 If you would like Grub to automatically update when a snapshot is made or deleted:

--- a/config
+++ b/config
@@ -74,3 +74,14 @@ GRUB_BTRFS_IGNORE_SPECIFIC_PATH=("@" "var/lib/docker" "@var/lib/docker")
 # Might be 'grub2-mkconfig' on some systems
 # Default: /usr/bin/grub-mkconfig
 #GRUB_BTRFS_MKCONFIG=/usr/bin/grub2-mkconfig
+
+## Password protection management for submenu,snapshots
+# Add authorized usernames separate by comma (foo,bar)
+# When Grub's password protection is enabled, the superuser is authorized by default, it isn't necessary to add it
+# Default:
+# GRUB_BTRFS_PROTECTION_AUTHORIZED_USERS=""
+#
+# Disable authentication support for submenu of Grub-btrfs only (--unrestricted)
+# doesn't work if GRUB_BTRFS_PROTECTION_AUTHORIZED_USERS isn't empty
+# Default: false
+# GRUB_BTRFS_DISABLE_PROTECTION_SUBMENU="false"


### PR DESCRIPTION
Grub2 supports superuser and user access using passwords. #95

-Ability to add authorized users.
-Possibility to disable password protection for the submenu.