### PR TITLE
Add uninstall to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,12 @@ install:
 	@install -Dm644 -t "$(LIB_DIR)/systemd/system/" grub-btrfs.service
 	@install -Dm644 -t "$(LIB_DIR)/systemd/system/" grub-btrfs.path
 	@install -Dm644 -t "$(SHARE_DIR)/licenses/$(PKGNAME)/" LICENSE
+
+uninstall:
+	rm -f "$(DESTDIR)/etc/grub.d/41_snapshots-btrfs"
+	rm -f "$(DESTDIR)/etc/default/grub-btrfs/config"
+	rmdir --ignore-fail-on-non-empty "$(DESTDIR)/etc/default/grub-btrfs"
+	rm -f "$(LIB_DIR)/systemd/system/grub-btrfs.service"
+	rm -f "$(LIB_DIR)/systemd/system/grub-btrfs.path"
+	rm -f "$(SHARE_DIR)/licenses/$(PKGNAME)/LICENSE"
+	rm -f "$(DESTDIR)/boot/grub/grub-btrfs.cfg"


### PR DESCRIPTION
With the manual installation it's useful to be able to clean up what's been installed with the Makefile to maintain the filesystem clean.