### PR TITLE
Improved sorting of the subvolumes list

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -76,11 +76,7 @@ microcode=("${GRUB_BTRFS_CUSTOM_MICROCODE[@]}")
 ## Limit snapshots to show in the Grub menu
 limit_snap_show="${GRUB_BTRFS_LIMIT:-50}"
 ## How to sort snapshots list
-snap_list_sort=${GRUB_BTRFS_SUBVOLUME_SORT:-"descending"}
-case "${snap_list_sort}" in
-    ascending)          btrfssubvolsort=("--sort=+rootid");;
-    *)                  btrfssubvolsort=("--sort=-rootid")
-esac
+btrfssubvolsort=(--sort="${GRUB_BTRFS_SUBVOLUME_SORT:-"-rootid"}")
 ## Show snapshots found during run "grub-mkconfig"
 show_snap_found=${GRUB_BTRFS_SHOW_SNAPSHOTS_FOUND:-"true"}
 ## Show Total of snapshots found during run "grub-mkconfig"

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ You have the possibility to modify many parameters in `/etc/default/grub-btrfs/c
 
 	Limit the number of snapshots populated in the GRUB menu.
 
-* GRUB_BTRFS_SUBVOLUME_SORT="descending"
+* GRUB_BTRFS_SUBVOLUME_SORT="+ogen,-gen,path,rootid"
 
-	Sort the found subvolumes by newest first ("descending") or oldest first ("ascending"). 
+	Sort the found subvolumes by "ogeneration" or "generation" or "path" or "rootid".
 	
-	If "ascending" is chosen then 
+	Default: "-rootid" means list snapshot by new ones first
 	
-	the $GRUB_BTRFS_LIMIT oldest subvolumes will populate the menu.
+	See [Sorting section](https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-subvolume#SUBCOMMAND)
 
 * GRUB_BTRFS_SHOW_SNAPSHOTS_FOUND="true"
 	

--- a/config
+++ b/config
@@ -21,9 +21,10 @@
 # Default: "50"
 #GRUB_BTRFS_LIMIT="50"
 
-# Sort the found subvolumes by newest first ("descending") or oldest first ("ascending") and show $GRUB_BTRFS_LIMIT first entries.
-# Default: "descending"
-#GRUB_BTRFS_SUBVOLUME_SORT="descending"
+# Sort the found subvolumes by "ogeneration" or "generation" or "path" or "rootid"
+# Default: "-rootid"
+# See Sorting section to https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-subvolume#SUBCOMMAND
+#GRUB_BTRFS_SUBVOLUME_SORT="+ogen,-gen,path,rootid"
 
 # Show snapshots found during run "grub-mkconfig"
 # Default: "true"


### PR DESCRIPTION
Add functionality to sort subvolume list by: rootid,gen,ogen,path
Default: "-rootid" means list snapshot by new ones first
See [Sorting section](https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-subvolume#SUBCOMMAND)
