### PR TITLE
Modify the function which is used to ignore a path.

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -80,6 +80,8 @@ show_snap_found=${GRUB_BTRFS_SHOW_SNAPSHOTS_FOUND:-"true"}
 show_total_snap_found=${GRUB_BTRFS_SHOW_TOTAL_SNAPSHOTS_FOUND:-"true"}
 ## Ignore specific path during run "grub-mkconfig"
 ignore_specific_path=("${GRUB_BTRFS_IGNORE_SPECIFIC_PATH[@]}")
+## Ignore prefix path during run "grub-mkconfig"
+ignore_prefix_path=("${GRUB_BTRFS_IGNORE_PREFIX_PATH[@]}")
 ## Snapper's config name
 snapper_config=${GRUB_BTRFS_SNAPPER_CONFIG:-"root"}
 ## Override boot partition detection

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -267,9 +267,13 @@ snapshot_list()
 
 		# ignore specific path during run "grub-mkconfig"
 		if [ ! -z "${ignore_specific_path}" ] ; then
-			[[ "${snap_path_name}" == "@" ]] && continue 2;
 			for isp in ${ignore_specific_path[@]} ; do
-				[[ "${snap_path_name}" == "${isp}" || "${snap_path_name}" == "${isp}"/* ]] && continue 2;
+				[[ "${snap_path_name}" == "${isp}" ]] && continue 2;
+			done
+		fi
+		if [ ! -z "${ignore_prefix_path}" ] ; then
+			for isp in ${ignore_prefix_path[@]} ; do
+				[[ "${snap_path_name}" == "${isp}"/* ]] && continue 2;
 			done
 		fi
 

--- a/config
+++ b/config
@@ -55,14 +55,16 @@
 #GRUB_BTRFS_CUSTOM_MICROCODE=("custom-ucode.img" "custom-uc.img "custom_ucode.cpio")
 
 # Ignore specific path during run "grub-mkconfig".
-# If path is a directory, # Found Snapshot: 2016-03-31 10:24:41 var/lib/docker/btrfs/subvolumes/...
-# use : GRUB_BTRFS_IGNORE_SPECIFIC_PATH=("var/lib/docker");
-# If path is a subvolume, # Found Snapshot: 2016-03-31 10:24:41 @var/lib/docker/btrfs/subvolumes/...
-# use : GRUB_BTRFS_IGNORE_SPECIFIC_PATH=("@var/lib/docker");
-# You can combine them
-# use : GRUB_BTRFS_IGNORE_SPECIFIC_PATH=("@var/lib/docker" "var/lib/docker")
-# Default: ("var/lib/docker" "@var/lib/docker" "@/var/lib/docker") and "@" subvolume is hardcode.
-GRUB_BTRFS_IGNORE_SPECIFIC_PATH=("var/lib/docker" "@var/lib/docker" "@/var/lib/docker")
+# Only exact paths are ignored.
+# e.g : if `specific path` = @, only `@` snapshot will be ignored.
+# Default: ("@")
+GRUB_BTRFS_IGNORE_SPECIFIC_PATH=("@")
+
+# Ignore prefix path during run "grub-mkconfig".
+# Any path starting with the specified string will be ignored.
+# e.g : if `prefix path` = @, all snapshots beginning with "@/..." will be ignored.
+# Default: ("var/lib/docker" "@var/lib/docker" "@/var/lib/docker")
+GRUB_BTRFS_IGNORE_PREFIX_PATH=("var/lib/docker" "@var/lib/docker" "@/var/lib/docker")
 
 # By default "grub-btrfs" automatically detects your boot partition,
 # either located at the system root or on a separate partition,


### PR DESCRIPTION
* Modify the function which is used to ignore a path.
`@` shouldn't be hardcoded.
Create 2 separate functions to ignore a `specific path` or `prefix path`.
In `specific path`, only exact paths are ignored.
In `prefix path`, any path starting with the specified string will be ignored.
e.g : 
if `specific path` = @, only `@` snapshot will be ignored.
if `prefix path` = @, all snapshots beginning with "@/..." will be ignored.