### PR TITLE
Modify "grub btrfs dirname" variable.

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -66,7 +66,7 @@ btrfssubvolsort=(--sort="${GRUB_BTRFS_SUBVOLUME_SORT:-"-rootid"}")
 ## Snapper's config name
 snapper_config=${GRUB_BTRFS_SNAPPER_CONFIG:-"root"}
 ## Customize GRUB directory
-grub_directory=${GRUB_BTRFS_DIRNAME:-"grub"}
+grub_directory=${GRUB_BTRFS_DIRNAME:-"/boot/grub"}
 ## Password protection management for submenu
 # Protection support for submenu (--unrestricted)
 case "${GRUB_BTRFS_DISABLE_PROTECTION_SUBMENU:-"false"}" in
@@ -81,13 +81,13 @@ fi
 ### variables script
 ## Probe info "Boot partition"
 # Boot device
-boot_device=$(${grub_probe} --target=device /boot)
+boot_device=$(${grub_probe} --target=device ${grub_directory})
 # hints string
 boot_hs=$(${grub_probe} --device ${boot_device} --target="hints_string" 2>/dev/null)
 # UUID of the boot partition
 boot_uuid=$(${grub_probe} --device ${boot_device} --target="fs_uuid" 2>/dev/null)
 # Type filesystem of boot partition
-boot_fs=$(${grub_probe} --target="fs" /boot 2>/dev/null)
+boot_fs=$(${grub_probe} --target="fs" ${grub_directory} 2>/dev/null)
 ## Probe info "Root partition"
 # Type filesystem of root partition
 root_fs=$(${grub_probe} --target="fs" / 2>/dev/null)
@@ -138,7 +138,7 @@ test_btrfs()
 ## Create entry
 entry()
 {
-echo "$@" >> "/boot/$grub_directory/grub-btrfs.cfg"
+echo "$@" >> "$grub_directory/grub-btrfs.cfg"
 }
 
 ## menu entries
@@ -496,8 +496,8 @@ printf "Detecting snapshots ...\n" >&2 ;
 # Only support btrfs snapshots
 test_btrfs
 # Delete existing config
-#rm -f --preserve-root "/boot/$grub_directory/grub-btrfs.cfg"
-> "/boot/$grub_directory/grub-btrfs.cfg"
+#rm -f --preserve-root "$grub_directory/grub-btrfs.cfg"
+> "$grub_directory/grub-btrfs.cfg"
 # Create mount point then mounting
 [[ ! -d $gbgmp ]] && mkdir -p $gbgmp
 mount -o subvolid=5 /dev/disk/by-uuid/$root_uuid $gbgmp/

--- a/config
+++ b/config
@@ -73,11 +73,10 @@ GRUB_BTRFS_IGNORE_PREFIX_PATH=("var/lib/docker" "@var/lib/docker" "@/var/lib/doc
 # Default: "false"
 #GRUB_BTRFS_OVERRIDE_BOOT_PARTITION_DETECTION="true"
 
-# GRUB folder location, by default "/boot/" is hardcode.
-# Might be grub2 on some systems ex. /boot/grub2/...
-# "grub" means "/boot/grub/"
-# Default: "grub"
-#GRUB_BTRFS_DIRNAME="grub2"
+# GRUB folder location.
+# Might be grub2 on some systems.
+# Default: "/boot/grub"
+#GRUB_BTRFS_DIRNAME="/boot/grub2"
 
 # Name/path of grub-mkconfig, use by "grub-btrfs.service"
 # Might be 'grub2-mkconfig' on some systems

--- a/grub-btrfs.service
+++ b/grub-btrfs.service
@@ -8,4 +8,4 @@ Environment="PATH=/sbin:/bin:/usr/sbin:/usr/bin"
 # Load environment variables from the configuration
 EnvironmentFile=/etc/default/grub-btrfs/config
 # Regenerate just '/boot/grub/grub-btrfs.cfg' if it exists and is not empty, else regenerate the whole grub menu
-ExecStart=/bin/bash -c 'if [ -s "${GRUB_BTRFS_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else ${GRUB_BTRFS_MKCONFIG:-/usr/bin/grub-mkconfig} -o /boot/${GRUB_BTRFS_DIRNAME:-/boot/grub}/grub.cfg; fi'
+ExecStart=/bin/bash -c 'if [ -s "${GRUB_BTRFS_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else ${GRUB_BTRFS_MKCONFIG:-/usr/bin/grub-mkconfig} -o ${GRUB_BTRFS_DIRNAME:-/boot/grub}/grub.cfg; fi' 

--- a/grub-btrfs.service
+++ b/grub-btrfs.service
@@ -8,4 +8,4 @@ Environment="PATH=/sbin:/bin:/usr/sbin:/usr/bin"
 # Load environment variables from the configuration
 EnvironmentFile=/etc/default/grub-btrfs/config
 # Regenerate just '/boot/grub/grub-btrfs.cfg' if it exists and is not empty, else regenerate the whole grub menu
-ExecStart=/bin/bash -c 'if [ -s "/boot/${GRUB_BTRFS_DIRNAME:-grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else ${GRUB_BTRFS_MKCONFIG:-/usr/bin/grub-mkconfig} -o /boot/${GRUB_BTRFS_DIRNAME:-grub}/grub.cfg; fi'
+ExecStart=/bin/bash -c 'if [ -s "${GRUB_BTRFS_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else ${GRUB_BTRFS_MKCONFIG:-/usr/bin/grub-mkconfig} -o /boot/${GRUB_BTRFS_DIRNAME:-grub}/grub.cfg; fi'

--- a/grub-btrfs.service
+++ b/grub-btrfs.service
@@ -8,4 +8,4 @@ Environment="PATH=/sbin:/bin:/usr/sbin:/usr/bin"
 # Load environment variables from the configuration
 EnvironmentFile=/etc/default/grub-btrfs/config
 # Regenerate just '/boot/grub/grub-btrfs.cfg' if it exists and is not empty, else regenerate the whole grub menu
-ExecStart=/bin/bash -c 'if [ -s "${GRUB_BTRFS_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else ${GRUB_BTRFS_MKCONFIG:-/usr/bin/grub-mkconfig} -o /boot/${GRUB_BTRFS_DIRNAME:-grub}/grub.cfg; fi'
+ExecStart=/bin/bash -c 'if [ -s "${GRUB_BTRFS_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else ${GRUB_BTRFS_MKCONFIG:-/usr/bin/grub-mkconfig} -o /boot/${GRUB_BTRFS_DIRNAME:-/boot/grub}/grub.cfg; fi'


### PR DESCRIPTION
### Modify "GRUB_BTRFS_DIRNAME" variable
* Script / config file / grub-btrfs.service
  * Full path to Grub folder is now configurable (/boot is no longer hard coded).
  * Detection of the boot partition is now based on the location of the Grub folder. 