### PR TITLE
Fix #116

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -65,8 +65,10 @@ limit_snap_show="${GRUB_BTRFS_LIMIT:-50}"
 btrfssubvolsort=(--sort="${GRUB_BTRFS_SUBVOLUME_SORT:-"-rootid"}")
 ## Snapper's config name
 snapper_config=${GRUB_BTRFS_SNAPPER_CONFIG:-"root"}
-## Customize GRUB directory
-grub_directory=${GRUB_BTRFS_DIRNAME:-"/boot/grub"}
+## Customize GRUB directory, where "grub.cfg" file is saved
+grub_directory=${GRUB_BTRFS_GRUB_DIRNAME:-"/boot/grub"}
+## Customize BOOT directory, where kernels/initrams/microcode is saved.
+boot_directory=${GRUB_BTRFS_BOOT_DIRNAME:-"/boot"}
 ## Password protection management for submenu
 # Protection support for submenu (--unrestricted)
 case "${GRUB_BTRFS_DISABLE_PROTECTION_SUBMENU:-"false"}" in
@@ -81,13 +83,13 @@ fi
 ### variables script
 ## Probe info "Boot partition"
 # Boot device
-boot_device=$(${grub_probe} --target=device ${grub_directory})
+boot_device=$(${grub_probe} --target=device ${boot_directory})
 # hints string
 boot_hs=$(${grub_probe} --device ${boot_device} --target="hints_string" 2>/dev/null)
 # UUID of the boot partition
 boot_uuid=$(${grub_probe} --device ${boot_device} --target="fs_uuid" 2>/dev/null)
 # Type filesystem of boot partition
-boot_fs=$(${grub_probe} --target="fs" ${grub_directory} 2>/dev/null)
+boot_fs=$(${grub_probe} --device ${boot_device} --target="fs" 2>/dev/null)
 ## Probe info "Root partition"
 # Type filesystem of root partition
 root_fs=$(${grub_probe} --target="fs" / 2>/dev/null)
@@ -410,7 +412,7 @@ boot_bounded()
 		snap_date_time="$(echo "$item" | cut -d' ' -f1-2)"
 		snap_date_time="$(trim "$snap_date_time")"
 		
-		boot_dir="$gbgmp/$snap_dir_name/boot"
+		boot_dir="$gbgmp/$snap_dir_name$boot_directory"
 		# Kernel (Original + custom kernel)
 		detect_kernel
 		if [ -z "${list_kernel}" ]; then continue; fi
@@ -444,7 +446,7 @@ boot_bounded()
 }
 boot_separate()
 {
-	boot_dir="/boot"
+	boot_dir="${boot_directory}"
 	# convert /boot directory to root of GRUB (e.g /boot become /)
 	boot_dir_root_grub="$(make_system_path_relative_to_its_root "${boot_dir}")"
 

--- a/config
+++ b/config
@@ -73,13 +73,21 @@ GRUB_BTRFS_IGNORE_PREFIX_PATH=("var/lib/docker" "@var/lib/docker" "@/var/lib/doc
 # Default: "false"
 #GRUB_BTRFS_OVERRIDE_BOOT_PARTITION_DETECTION="true"
 
-# GRUB folder location.
+# Location of the folder containing the "grub.cfg" file.
+# Use by grub-btrfs to save the file "grub-btrfs.cfg".
 # Might be grub2 on some systems.
+# For example, on Fedora with EFI : "/boot/efi/EFI/fedora"
 # Default: "/boot/grub"
-#GRUB_BTRFS_DIRNAME="/boot/grub2"
+#GRUB_BTRFS_GRUB_DIRNAME="/boot/grub2"
+
+# Location of kernels/initramfs/microcode.
+# Use by "grub-btrfs" to detect the boot partition and the location of kernels/initrafms/microcodes.
+# Default: "/boot"
+#GRUB_BTRFS_BOOT_DIRNAME="/boot"
 
 # Name/path of grub-mkconfig, use by "grub-btrfs.service"
 # Might be 'grub2-mkconfig' on some systems
+# For example, on Fedora : "/sbin/grub2-mkconfig"
 # Default: /usr/bin/grub-mkconfig
 #GRUB_BTRFS_MKCONFIG=/usr/bin/grub2-mkconfig
 


### PR DESCRIPTION
  * Renames variable `GRUB_BTRFS_DIRNAME` to `GRUB_BTRFS_GRUB_DIRNAME` and improves its description.

  * Adds variable `GRUB_BTRFS_BOOT_DIRNAME`, used to detect the boot partition and the location of kernels/initrafms/microcodes.