### PR TITLE
Corrects an erroneous variable

### DIFF
--- a/grub-btrfs.service
+++ b/grub-btrfs.service
@@ -8,4 +8,4 @@ Environment="PATH=/sbin:/bin:/usr/sbin:/usr/bin"
 # Load environment variables from the configuration
 EnvironmentFile=/etc/default/grub-btrfs/config
 # Regenerate just '/boot/grub/grub-btrfs.cfg' if it exists and is not empty, else regenerate the whole grub menu
-ExecStart=/bin/bash -c 'if [ -s "${GRUB_BTRFS_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else ${GRUB_BTRFS_MKCONFIG:-/usr/bin/grub-mkconfig} -o ${GRUB_BTRFS_DIRNAME:-/boot/grub}/grub.cfg; fi' 
+ExecStart=/bin/bash -c 'if [ -s "${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else ${GRUB_BTRFS_MKCONFIG:-/usr/bin/grub-mkconfig} -o ${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub.cfg; fi' 


### PR DESCRIPTION
Fix #127 
Replaces "GRUB_BTRFS_DIRNAME" variable to match with new variable "GRUB_BTRFS_GRUB_DIRNAME" in config file.