### PR TITLE
Improves systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ If you would like Grub to automatically update when a snapshot is made or delete
 		and finally save.
 	* You can view your change to `systemctl cat grub-btrfs.path`.
 	* To revert change use `systemctl revert grub-btrfs.path`.
+##### Warning:
+by default, `grub-mkconfig` command is used.  
+Might be `grub2-mkconfig` on some systems (Fedora ...).   
+Edit `GRUB_BTRFS_MKCONFIG` variable in `/etc/default/grub-btrfs/config` file to reflect this.
 ##
 ### Special thanks for assistance and contributions
 * [maximbaz](https://github.com/maximbaz)

--- a/config
+++ b/config
@@ -85,10 +85,13 @@ GRUB_BTRFS_IGNORE_PREFIX_PATH=("var/lib/docker" "@var/lib/docker" "@/var/lib/doc
 # Default: "/boot"
 #GRUB_BTRFS_BOOT_DIRNAME="/boot"
 
-# Name/path of grub-mkconfig, use by "grub-btrfs.service"
-# Might be 'grub2-mkconfig' on some systems
+# Name/path of grub-mkconfig command, use by "grub-btrfs.service"
+# Might be 'grub2-mkconfig' on some systems (Fedora ...)
+# Default paths are /sbin:/bin:/usr/sbin:/usr/bin,
+# if your path is missing, report it on the upstream project.
 # For example, on Fedora : "/sbin/grub2-mkconfig"
-# Default: /usr/bin/grub-mkconfig
+# You can use only name or full path.
+# Default: grub-mkconfig
 #GRUB_BTRFS_MKCONFIG=/usr/bin/grub2-mkconfig
 
 # Snapper

--- a/grub-btrfs.service
+++ b/grub-btrfs.service
@@ -8,4 +8,4 @@ Environment="PATH=/sbin:/bin:/usr/sbin:/usr/bin"
 # Load environment variables from the configuration
 EnvironmentFile=/etc/default/grub-btrfs/config
 # Regenerate just '/boot/grub/grub-btrfs.cfg' if it exists and is not empty, else regenerate the whole grub menu
-ExecStart=/bin/bash -c 'if [ -s "${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else ${GRUB_BTRFS_MKCONFIG:-/usr/bin/grub-mkconfig} -o ${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub.cfg; fi' 
+ExecStart=bash -c 'if [ -s "${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else ${GRUB_BTRFS_MKCONFIG:-grub-mkconfig} -o ${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub.cfg; fi' 


### PR DESCRIPTION
### Improves systemd service:

**grub-btrfs.service**: remove unnecessary path for bash and grub-mkconfig command
**readme.md**: add warning section to systemd service section
**config file**: Improves the description of the variable GRUB_BTRFS_MKCONFIG