### PR TITLE
add a new config variable GRUB_BTRFS_ROOTFLAGS

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -118,8 +118,8 @@ fi
 ## Detect rootflags
 detect_rootflags()
 {
-    local fstabflags=$(grep -oE '^\s*[^#][[:print:]]+\s+/\s+btrfs\s+[[:print:]]+' ${gbgmp}/${snap_dir_name}/etc/fstab \
-                        | sed -E 's/^.*[[:space:]]([[:print:]]+)$/\1/;s/,?subvol(id)?=[^,$]+//g;s/^,//')
+    local fstabflags=$(grep -oE '^\s*[^#][[:graph:]]+\s+/\s+btrfs\s+[[:graph:]]+' ${gbgmp}/${snap_dir_name}/etc/fstab \
+                        | sed -E 's/^.*[[:space:]]([[:graph:]]+)$/\1/;s/,?subvol(id)?=[^,$]+//g;s/^,//')
     rootflags="rootflags=${fstabflags:+$fstabflags,}${GRUB_BTRFS_ROOTFLAGS:+$GRUB_BTRFS_ROOTFLAGS,}"
 }
 

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -190,7 +190,7 @@ make_menu_entries()
         fi
         echo 'Loading Snapshot: "${snap_date_time}" "${snap_dir_name}"'
         echo 'Loading Kernel: "${k}" ...'
-        linux \"${boot_dir_root_grub}/"${k}"\" root="${LINUX_ROOT_DEVICE}" rw ${kernel_parameters} ${rootflags}subvol=\""${snap_dir_name}"\""
+        linux \"${boot_dir_root_grub}/"${k}"\" root="${LINUX_ROOT_DEVICE}" ${kernel_parameters} ${rootflags}subvol=\""${snap_dir_name}"\""
                 if [[ "${name_microcode}" != "x" ]] ; then
                     entry "\
         echo 'Loading Microcode & Initramfs: "${u}" "${i}" ...'

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -118,8 +118,9 @@ fi
 ## Detect rootflags
 detect_rootflags()
 {
-    rootflags="rootflags=${GRUB_BTRFS_ROOTFLAGS:+$GRUB_BTRFS_ROOTFLAGS,}"
-    # TODO: parse <snapshot>/etc/fstab and append mount options from there
+    local fstabflags=$(grep -oE '^\s*[^#][[:print:]]+\s+/\s+btrfs\s+[[:print:]]+' ${gbgmp}/${snap_dir_name}/etc/fstab \
+                        | sed -E 's/^.*[[:space:]]([[:print:]]+)$/\1/;s/,?subvol(id)?=[^,$]+//g;s/^,//')
+    rootflags="rootflags=${fstabflags:+$fstabflags,}${GRUB_BTRFS_ROOTFLAGS:+$GRUB_BTRFS_ROOTFLAGS,}"
 }
 
 ### Error Handling
@@ -423,6 +424,8 @@ boot_bounded()
         detect_kernel
         if [ -z "${list_kernel}" ]; then continue; fi
         name_kernel=("${list_kernel[@]##*"/"}")
+        # Detect rootflags
+        detect_rootflags
         # Initramfs (Original + custom initramfs)
         detect_initramfs
         if [ -z "${list_initramfs}" ]; then continue; fi
@@ -478,6 +481,8 @@ boot_separate()
         snap_dir_name="$(trim "$snap_dir_name")"
         snap_date_time="$(echo "$item" | cut -d' ' -f1-2)"
         snap_date_time="$(trim "$snap_date_time")"
+        # Detect rootflags
+        detect_rootflags
         # show snapshot found during run "grub-mkconfig"
         if [[ "${GRUB_BTRFS_SHOW_SNAPSHOTS_FOUND:-"true"}" = "true" ]]; then
             printf "Found snapshot: %s\n" "$item" >&2 ;
@@ -511,8 +516,6 @@ mount -o subvolid=5 /dev/disk/by-uuid/$root_uuid $gbgmp/
 count_warning_menuentries=0
 # Count snapshots
 count_limit_snap=0
-# Detect rootflags
-detect_rootflags
 # detect uuid requirement
 check_uuid_required
 # Detects if /boot is a separate partition

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -118,7 +118,7 @@ fi
 ## Detect rootflags
 detect_rootflags()
 {
-    local fstabflags=$(grep -oE '^\s*[^#][[:graph:]]+\s+/\s+btrfs\s+[[:graph:]]+' ${gbgmp}/${snap_dir_name}/etc/fstab \
+    local fstabflags=$(grep -oE '^\s*[^#][[:graph:]]+\s+/\s+btrfs\s+[[:graph:]]+' "${gbgmp}/${snap_dir_name}/etc/fstab" \
                         | sed -E 's/^.*[[:space:]]([[:graph:]]+)$/\1/;s/,?subvol(id)?=[^,$]+//g;s/^,//')
     rootflags="rootflags=${fstabflags:+$fstabflags,}${GRUB_BTRFS_ROOTFLAGS:+$GRUB_BTRFS_ROOTFLAGS,}"
 }

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -115,6 +115,12 @@ else
     LINUX_ROOT_DEVICE=UUID=${root_uuid}
 fi
 }
+## Detect rootflags
+detect_rootflags()
+{
+    rootflags="rootflags=${GRUB_BTRFS_ROOTFLAGS:+$GRUB_BTRFS_ROOTFLAGS,}"
+    # TODO: parse <snapshot>/etc/fstab and append mount options from there
+}
 
 ### Error Handling
 print_error()
@@ -183,7 +189,7 @@ make_menu_entries()
         fi
         echo 'Loading Snapshot: "${snap_date_time}" "${snap_dir_name}"'
         echo 'Loading Kernel: "${k}" ...'
-        linux \"${boot_dir_root_grub}/"${k}"\" root="${LINUX_ROOT_DEVICE}" rw ${kernel_parameters} rootflags=subvol=\""${snap_dir_name}"\""
+        linux \"${boot_dir_root_grub}/"${k}"\" root="${LINUX_ROOT_DEVICE}" rw ${kernel_parameters} ${rootflags}subvol=\""${snap_dir_name}"\""
                 if [[ "${name_microcode}" != "x" ]] ; then
                     entry "\
         echo 'Loading Microcode & Initramfs: "${u}" "${i}" ...'
@@ -505,6 +511,8 @@ mount -o subvolid=5 /dev/disk/by-uuid/$root_uuid $gbgmp/
 count_warning_menuentries=0
 # Count snapshots
 count_limit_snap=0
+# Detect rootflags
+detect_rootflags
 # detect uuid requirement
 check_uuid_required
 # Detects if /boot is a separate partition

--- a/config
+++ b/config
@@ -54,6 +54,11 @@
 # Default: ("")
 #GRUB_BTRFS_CUSTOM_MICROCODE=("custom-ucode.img" "custom-uc.img "custom_ucode.cpio")
 
+# Comma seperated mount options to be used when booting a snapshot.
+# You do NOT need to include "subvol=..." or "subvolid=...".
+# Default: ""
+#GRUB_BTRFS_ROOTFLAGS="noatime,compress=zstd:7,commit=10,norecovery"
+
 # Ignore specific path during run "grub-mkconfig".
 # Only exact paths are ignored.
 # e.g : if `specific path` = @, only `@` snapshot will be ignored.

--- a/config
+++ b/config
@@ -55,9 +55,12 @@
 #GRUB_BTRFS_CUSTOM_MICROCODE=("custom-ucode.img" "custom-uc.img "custom_ucode.cpio")
 
 # Comma seperated mount options to be used when booting a snapshot.
-# You do NOT need to include "subvol=..." or "subvolid=...".
+# They can be defined here as well as in the "/" line inside the respective snapshots'
+# "/etc/fstab" files.  Mount options found in both places are combined, and this variable
+# takes priority over `fstab` entries.
+# NB: Do NOT include "subvol=..." or "subvolid=..." here.
 # Default: ""
-#GRUB_BTRFS_ROOTFLAGS="noatime,compress=zstd:7,commit=10,norecovery"
+#GRUB_BTRFS_ROOTFLAGS="space_cache,commit=10,norecovery"
 
 # Ignore specific path during run "grub-mkconfig".
 # Only exact paths are ignored.


### PR DESCRIPTION
**TODO:** parse <snapshot>/etc/fstab and append mount options from there

Hi @Antynea !

I'm wondering what your thoughts are about possible duplicate options in the config variable and `fstab`. For example, the variable contains `discard`, and in `fstab` we find this too, or even worse, `nodiscard`. Should we check for such ambiguities/redundancies, or should it be up to the user that their configuration is consistent ?

Second, which options should go first - `$GRUB_BTRFS_ROOTFLAGS,$(mount options from fstab)` or the other way around ?