### PR TITLE
Improves systemd.path unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See [config file](https://github.com/Antynea/grub-btrfs/blob/master/config) for 
 
 ##
 ### Automatically update grub
-If you would like grub-btrfs menu to automatically update when a snapshot is created or deleted:
+1- If you would like grub-btrfs menu to automatically update when a snapshot is created or deleted:
 * Use `systemctl enable grub-btrfs.path`.
   * `grub-btrfs.path` automatically (re)generates `grub-btrfs.cfg` when a modification appears in `/.snapshots` mount point (by default).
   * If the `/.snapshots` mount point is already mounted, then use `systemctl start grub-btrfs.path` to start monitoring.  
@@ -87,6 +87,10 @@ use `systemctl list-units -t mount`.
 		Otherwise, the unit will automatically start monitoring when the mount point will be available.  
 	* You can view your change to `systemctl cat grub-btrfs.path`.
 	* To revert change use `systemctl revert grub-btrfs.path`.
+
+2- If you would like grub-btrfs menu to automatically update on system restart/shutdown:  
+[Look at this comment](https://github.com/Antynea/grub-btrfs/issues/138#issuecomment-766918328)  
+Currently not implemented  
 ##### Warning :
 by default, `grub-mkconfig` command is used.  
 Might be `grub2-mkconfig` on some systems (Fedora ...).   

--- a/grub-btrfs.path
+++ b/grub-btrfs.path
@@ -1,8 +1,12 @@
 [Unit]
 Description=Monitors for new snapshots
+DefaultDependencies=no
+Requires=\x2esnapshots.mount
+After=\x2esnapshots.mount
+BindsTo=\x2esnapshots.mount
 
 [Path]
 PathModified=/.snapshots
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=\x2esnapshots.mount


### PR DESCRIPTION
* grub-btrfs.path : improves unit  
Allows the unit to start and stop automatically when the mount point is detected.  
If the mount point is already mounted when the unit is activated `systemctl enable grub-btrfs.path`,  
it will be necessary to start the unit for monitoring to begin `systemctl start grub-btrfs.path`.
  -  `DefaultDependencies=no`
Prevents systemd from automatically generating `Wants= or Requires= or After=`.
  - `Requires=\x2esnapshots.mount`
Ensures unit is started if mount point exists.
  - `After=\x2esnapshots.mount`
Unit start after the mounting point exists.
  - `BindsTo=\x2esnapshots.mount`
If the mount point is removed, the unit will stop.
  - `PathModified=/.snapshots`
The monitored folder containing the snapshots.
  - `WantedBy=\x2esnapshots.mount`
If the mount point exists, unit start automatically. (only if unit is activated before the mount point is mounted)

* Readme : Update "Automatically update grub" section
Update "Automatically update grub" section following the recent change in the `grub-btrfs.path` unit.

Fix: #138 