### PR TITLE
Add filter snapper's snapshot

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -296,6 +296,18 @@ snapshot_list()
             if [[ "$snapper_id" == "$id" ]]; then
                 local snapper_type=$(trim "${snapper_types[$j]}")
                 local snapper_description=$(trim "${snapper_descriptions[$j]}")
+                
+                # ignore snapper_type or snapper_description during run "grub-mkconfig"
+                if [ ! -z "${GRUB_BTRFS_IGNORE_SNAPPER_TYPE}" ] ; then
+                    for ist in ${GRUB_BTRFS_IGNORE_SNAPPER_TYPE[@]} ; do
+                        [[ "${snapper_type}" == "${ist}" ]] && continue 3;
+                    done
+                fi
+                if [ ! -z "${GRUB_BTRFS_IGNORE_SNAPPER_DESCRIPTION}" ] ; then
+                    for isd in ${GRUB_BTRFS_IGNORE_SNAPPER_DESCRIPTION[@]} ; do
+                        [[ "${snapper_description}" == "${isd}" ]] && continue 3;
+                    done
+                fi
                 printf -v entry "%-${max_entry_length}s | %-${max_type_length}s | %s" "$entry" "$snapper_type" "$snapper_description"
                 break
             fi

--- a/config
+++ b/config
@@ -74,6 +74,15 @@ GRUB_BTRFS_IGNORE_SPECIFIC_PATH=("@")
 # Default: ("var/lib/docker" "@var/lib/docker" "@/var/lib/docker")
 GRUB_BTRFS_IGNORE_PREFIX_PATH=("var/lib/docker" "@var/lib/docker" "@/var/lib/docker")
 
+# Ignore specific type of snapper's snapshot during run "grub-mkconfig".
+# Type = number, timeline, pre, post.
+# Default: ("")
+GRUB_BTRFS_IGNORE_SNAPPER_TYPE=("")
+
+# Ignore specific description of snapper's snapshot during run "grub-mkconfig".
+# Default: ("")
+GRUB_BTRFS_IGNORE_SNAPPER_DESCRIPTION=("")
+
 # By default "grub-btrfs" automatically detects your boot partition,
 # either located at the system root or on a separate partition,
 # but cannot detect if it is in a subvolume.

--- a/config
+++ b/config
@@ -75,7 +75,7 @@ GRUB_BTRFS_IGNORE_SPECIFIC_PATH=("@")
 GRUB_BTRFS_IGNORE_PREFIX_PATH=("var/lib/docker" "@var/lib/docker" "@/var/lib/docker")
 
 # Ignore specific type of snapper's snapshot during run "grub-mkconfig".
-# Type = number, timeline, pre, post.
+# Type = single, pre, post.
 # Default: ("")
 GRUB_BTRFS_IGNORE_SNAPPER_TYPE=("")
 


### PR DESCRIPTION
Add filter to ignore snapper_type or snapper_description during run "grub-mkconfig".
fix #157 
