### PR TITLE
Fix bug Create entries with matching version

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -187,6 +187,7 @@ make_menu_entries()
                 elif [ "${kversion}.img" = "${suffix_i}" ];             then i="${i}";
                 elif [ "${kversion}-fallback.img" = "${suffix_i}" ];    then i="${i}";
                 elif [ "${kversion}.gz" = "${suffix_i}" ];              then i="${i}";
+                else continue;
                 fi
                 for u in "${name_microcode[@]}"; do
                     if [[ "${name_microcode}" != "x" ]] ; then


### PR DESCRIPTION
* Fix #169 
  * Create entries with matching version doesn't work properly:
  Adds missing "else continue;"