### PR TITLE
Make name of "grub-script-check" configurable

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -595,7 +595,7 @@ if [[ "${count_limit_snap}" = "0" || -z "${count_limit_snap}" ]]; then
     print_error "No snapshots found."
 fi
 # Make a submenu in GRUB (grub.cfg) and move "grub-btrfs.new" to "grub-btrfs.cfg"
-if ${grub_script_check} "$grub_directory/grub-btrfs.new"; then
+if ${GRUB_BTRFS_SCRIPT_CHECK:-"grub_script_check"} "$grub_directory/grub-btrfs.new"; then
     cat "$grub_directory/grub-btrfs.new" > "$grub_directory/grub-btrfs.cfg"
     rm -f "$grub_directory/grub-btrfs.new"
     cat << EOF

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -116,8 +116,6 @@ detect_rootflags()
                         | sed -E 's/^.*[[:space:]]([[:graph:]]+)$/\1/;s/,?subvol(id)?=[^,$]+//g;s/^,//')
     rootflags="rootflags=${fstabflags:+$fstabflags,}${GRUB_BTRFS_ROOTFLAGS:+$GRUB_BTRFS_ROOTFLAGS,}"
 }
-## Path to grub-script-check
-grub_script_check="${bindir}/grub-script-check"
 
 ## Error Handling
 print_error()
@@ -595,7 +593,7 @@ if [[ "${count_limit_snap}" = "0" || -z "${count_limit_snap}" ]]; then
     print_error "No snapshots found."
 fi
 # Make a submenu in GRUB (grub.cfg) and move "grub-btrfs.new" to "grub-btrfs.cfg"
-if ${GRUB_BTRFS_SCRIPT_CHECK:-"grub_script_check"} "$grub_directory/grub-btrfs.new"; then
+if "${bindir}/${GRUB_BTRFS_SCRIPT_CHECK:-grub-script-check}" "$grub_directory/grub-btrfs.new"; then
     cat "$grub_directory/grub-btrfs.new" > "$grub_directory/grub-btrfs.cfg"
     rm -f "$grub_directory/grub-btrfs.new"
     cat << EOF

--- a/config
+++ b/config
@@ -111,6 +111,11 @@ GRUB_BTRFS_IGNORE_SNAPPER_DESCRIPTION=("")
 # Default: grub-mkconfig
 #GRUB_BTRFS_MKCONFIG=/usr/bin/grub2-mkconfig
 
+# Path of grub-script-check command, use by "grub-btrfs"
+# Might be 'grub2-script-check' on some systems (Fedora ...)
+# For example, on Fedora : "/sbin/grub2-script-check"
+#GRUB_BTRFS_SCRIPT_CHECK=/usr/bin/grub2-script-check
+
 # Snapper
 # Snapper's config name to use
 # Default: "root"

--- a/config
+++ b/config
@@ -111,10 +111,11 @@ GRUB_BTRFS_IGNORE_SNAPPER_DESCRIPTION=("")
 # Default: grub-mkconfig
 #GRUB_BTRFS_MKCONFIG=/usr/bin/grub2-mkconfig
 
-# Path of grub-script-check command, use by "grub-btrfs"
+# Name of grub-script-check command, use by "grub-btrfs"
 # Might be 'grub2-script-check' on some systems (Fedora ...)
-# For example, on Fedora : "/sbin/grub2-script-check"
-#GRUB_BTRFS_SCRIPT_CHECK=/usr/bin/grub2-script-check
+# For example, on Fedora : "grub2-script-check"
+# Default: grub-script-check
+#GRUB_BTRFS_SCRIPT_CHECK=grub2-script-check
 
 # Snapper
 # Snapper's config name to use


### PR DESCRIPTION
 * Makes path of grub-script-check configurable:
   * Might be 'grub2-script-check' on some systems (Fedora ...)