### PR TITLE
Make path of "grub-mkconfig_lib" configurable

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -36,7 +36,6 @@
 
 set -e
 
-datarootdir="/usr/share"
 sysconfdir="/etc"
 grub_btrfs_config="${sysconfdir}/default/grub-btrfs/config"
 
@@ -46,7 +45,7 @@ grub_btrfs_config="${sysconfdir}/default/grub-btrfs/config"
 ## Exit the script, if:
 [[ "${GRUB_BTRFS_DISABLE,,}" == "true" ]] && exit 0 # Disable Grub-btrfs is set to true (default=false)
 if ! type btrfs >/dev/null 2>&1; then exit 0; fi # btrfs-progs isn't installed
-[[ -f "$datarootdir/grub/grub-mkconfig_lib" ]] && . "$datarootdir/grub/grub-mkconfig_lib" || exit 0 # grub-mkconfig_lib couldn't be found
+[[ -f "${GRUB_BTRFS_MKCONFIG_LIB:-/usr/share/grub/grub-mkconfig_lib}" ]] && . "${GRUB_BTRFS_MKCONFIG_LIB:-/usr/share/grub/grub-mkconfig_lib}" || exit 0 # grub-mkconfig_lib couldn't be found
 # Root filesystem isn't btrfs
 root_fs=$(${grub_probe} --target="fs" / 2>/dev/null)
 [[ "$root_fs" != "btrfs" ]] && exit 0

--- a/config
+++ b/config
@@ -112,6 +112,11 @@ GRUB_BTRFS_IGNORE_PREFIX_PATH=("var/lib/docker" "@var/lib/docker" "@/var/lib/doc
 # Default: grub-script-check
 #GRUB_BTRFS_SCRIPT_CHECK=grub2-script-check
 
+# Path of grub-mkconfig_lib file, use by "grub-btrfs"
+# Might be '/usr/share/grub2/grub-mkconfig_lib' on some systems (Opensuse ...)
+# Default: /usr/share/grub/grub-mkconfig_lib
+#GRUB_BTRFS_MKCONFIG_LIB=/usr/share/grub2/grub-mkconfig_lib
+
 # Password protection management for submenu,snapshots
 # Refer to the Grub documentation https://www.gnu.org/software/grub/manual/grub/grub.html#Authentication-and-authorisation
 # and this comment https://github.com/Antynea/grub-btrfs/issues/95#issuecomment-682295660


### PR DESCRIPTION
Fix #180 

Apparently on OpenSUSE, the `grub-mkconfig_lib` file is not located in the `/usr/share/grub` folder,
but in `/usr/share/grub2`.
These changes allow you to configure, the location and the name of the file.