### PR TITLE
Add missing initrd

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -400,10 +400,8 @@ detect_initramfs()
     list_initramfs=()
     # Original initramfs (auto-detect)
     for oinitramfs in   "${boot_dir}"/initrd.img-* \
-                        "${boot_dir}"/initrd-*.img \
-                        "${boot_dir}"/initrd-*.gz \
-                        "${boot_dir}"/initramfs-*.img \
-                        "${boot_dir}"/initramfs-*.gz ; do
+                        "${boot_dir}"/initramfs-* \
+                        "${boot_dir}"/initrd-* ; do
         [[ ! -f "${oinitramfs}" ]] && continue;
         list_initramfs+=("$oinitramfs")
     done


### PR DESCRIPTION
The list of inits was incomplete.
Quote from original list of `Grub`:
```
"initrd.img-${version}" "initrd-${version}.img" "initrd-${version}.gz" \
"initrd-${version}" "initramfs-${version}.img" \
"initrd.img-${alt_version}" "initrd-${alt_version}.img" \
"initrd-${alt_version}" "initramfs-${alt_version}.img" \
"initramfs-genkernel-${version}" \
"initramfs-genkernel-${alt_version}" \
"initramfs-genkernel-${GENKERNEL_ARCH}-${version}" \
"initramfs-genkernel-${GENKERNEL_ARCH}-${alt_version}"
```

This change solves #183