### PR TITLE
Add systemd volatile

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -162,8 +162,16 @@ echo "$@" >> "$grub_directory/grub-btrfs.new"
 }
 
 ## menu entries
+old_kernel_parameters=${kernel_parameters}
 make_menu_entries()
 {
+    kernel_parameters="${old_kernel_parameters}"
+    if [[ "${GRUB_BTRFS_SYSTEMD_VOLATILE}" == true ]] ; then
+        if [[ $(strings -n7 "$grub_btrfs_mount_point/$snap_dir_name_trim/usr/bin/init" | grep -aEiom1 'upstart|systemd|sysvinit') == systemd ]] \
+           || [[ $(strings -n7 "$grub_btrfs_mount_point/$snap_dir_name_trim/sbin/init" | grep -aEiom1 'upstart|systemd|sysvinit') == systemd ]]; then
+                [[ $(btrfs property get "$grub_btrfs_mount_point/$snap_dir_name_trim" ro) != "ro=false" ]] && kernel_parameters="${kernel_parameters} systemd.volatile=state";
+        fi
+    fi
 ## \" required for snap,kernels,init,microcode with space in their name
     entry "submenu '${title_menu}' {
     submenu '${title_submenu}' { echo }"

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Otherwise, make sure your snapshots are writeable.
 See [this ticket](https://github.com/Antynea/grub-btrfs/issues/92) for more info.
 
 This project includes its own solution.  
-Refer to the [documentation](https://github.com/Antynea/grub-btrfs/blob/master/initramfs/readme.md).
-
+* Refer to the [documentation](https://github.com/Antynea/grub-btrfs/blob/master/initramfs/readme.md).  
+* Or used `GRUB_BTRFS_SYSTEMD_VOLATILE=true` in config file. (experimental, See [config file](https://github.com/Antynea/grub-btrfs/blob/master/config) for more information.)
 - - -
 ### What does grub-btrfs v4.xx do :
 * Automatically List snapshots existing on root partition (btrfs).
@@ -51,13 +51,14 @@ Now merge grub-btrfs via
 `emerge app-backup/grub-btrfs`
 
 #### Manual
-
 * Run `make install` or look into Makefile for instructions on where to put each file.
+* Run `make help` to check what options are available.
 * Dependencies:
   * [btrfs-progs](https://archlinux.org/packages/core/x86_64/btrfs-progs/)
   * [grub](https://archlinux.org/packages/core/x86_64/grub/)
   * [bash >4](https://archlinux.org/packages/core/x86_64/bash/)
   * [gawk ](https://archlinux.org/packages/core/x86_64/gawk/)
+  * [strings](https://archlinux.org/packages/core/x86_64/binutils/)
 
 #### NOTE: All distros
 Generate your Grub menu after installation for the changes to take effect.  

--- a/config
+++ b/config
@@ -54,6 +54,16 @@
 # Default: ""
 #GRUB_BTRFS_ROOTFLAGS="space_cache,commit=10,norecovery"
 
+# Booting on read-only snapshots can be tricky. (See https://github.com/Antynea/grub-btrfs#warning-booting-on-read-only-snapshots-can-be-tricky)
+# Based on several reports, "/var" must be writable to start properly.
+# Systemd can do this for you. (not compatible with OpenRC)
+# The snapshot will boot in read-only mode but "/var" will be writable using a "tmpfs" mount point (which means, folder mounted in RAM)
+# This should make it easier to rollback.
+# Note to all: Detecting "systemd" as the default init on the snapshot is automatic, if don't, file a bug report at https://github.com/Antynea/grub-btrfs.
+# Note to Arch Linux users: If you use the "grub-btrfs-overlayfs" option on Arch Lunix, "GRUB_BTRFS_SYSTEMD_VOLATILE" will do nothing.
+# Default: "false"
+#GRUB_BTRFS_SYSTEMD_VOLATILE=true
+
 # Ignore specific path during run "grub-mkconfig".
 # Only exact paths are ignored.
 # e.g : if `specific path` = @, only `@` snapshot will be ignored.

--- a/config
+++ b/config
@@ -60,7 +60,7 @@
 # The snapshot will boot in read-only mode but "/var" will be writable using a "tmpfs" mount point (which means, folder mounted in RAM)
 # This should make it easier to rollback.
 # Note to all: Detecting "systemd" as the default init on the snapshot is automatic, if don't, file a bug report at https://github.com/Antynea/grub-btrfs.
-# Note to Arch Linux users: If you use the "grub-btrfs-overlayfs" option on Arch Lunix, "GRUB_BTRFS_SYSTEMD_VOLATILE" will do nothing.
+# Note to Arch Linux users: If you use the "grub-btrfs-overlayfs" option on Arch Linux, "GRUB_BTRFS_SYSTEMD_VOLATILE" will do nothing.
 # Default: "false"
 #GRUB_BTRFS_SYSTEMD_VOLATILE=true
 


### PR DESCRIPTION
These changes add support for `systemd-volatile=state`.
See https://github.com/Antynea/grub-btrfs/issues/92#issuecomment-966869223 for more information.

To use it:
Uncomment `#GRUB_BTRFS_SYSTEMD_VOLATILE=true` in config file.
The default init on the snapshot should be `systemd` (means, do nothing if systemd isn't detected on snapshot.)
The snapshot must have the tag `ro=true`.

If the automatic detection of `systemd` on snapshot doesn't work, please let me know.

@keyb0ardninja , Does this implementation suit you ?  I didn't want to activate this option by default, prefers to wait for more user feedback.