### PR TITLE
Update grub-btrfs.path

### DIFF
--- a/grub-btrfs.path
+++ b/grub-btrfs.path
@@ -9,4 +9,4 @@ BindsTo=\x2esnapshots.mount
 PathModified=/.snapshots
 
 [Install]
-WantedBy=\x2esnapshots.mount
+WantedBy=multi-user.target


### PR DESCRIPTION
```shell
sudo systemctl reenable grub-btrfs.path
Removed /etc/systemd/system/run-timeshift-backup.mount.wants/grub-btrfs.path.
Created symlink /etc/systemd/system/run-timeshift-backup.mount.wants/grub-btrfs.path → /etc/systemd/system/grub-btrfs.path.
Unit /etc/systemd/system/grub-btrfs.path is added as a dependency to a non-existent unit run-timeshift-backup.mount.
```