### PR TITLE
OpenRC scripts: add configuration file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ install:
 	@# OpenRC init system
 	@if test "$(OPENRC)" = true; then \
 		install -Dm744 -t "$(BIN_DIR)/" grub-btrfs-openrc; \
-		install -Dm744 -t "$(DESTDIR)/etc/init.d/" grub-btrfsd; \
+		install -Dm744 grub-btrfsd.initd "$(DESTDIR)/etc/init.d/grub-btrfsd"; \
+		install -Dm644 grub-btrfsd.confd "$(DESTDIR)/etc/conf.d/grub-btrfsd"; \
 	 fi
 	@# Arch Linux like distros only :
 	@if test "$(INITCPIO)" = true; then \

--- a/grub-btrfs-openrc
+++ b/grub-btrfs-openrc
@@ -1,6 +1,7 @@
 #!/bin/sh
 echo $$ > /run/grub-btrfsd.pid
+snapshots="${1:-/run/timeshift/backup/timeshift-btrfs/snapshots}"
 
-while true; do sleep 1 && inotifywait -e create -e delete /run/timeshift/backup/timeshift-btrfs/snapshots && sleep 5 && if [ -s "${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else ${GRUB_BTRFS_MKCONFIG:-grub-mkconfig} -o ${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub.cfg; fi  ; done
+while true; do sleep 1 && inotifywait -e create -e delete "$snapshots" && sleep 5 && if [ -s "${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else ${GRUB_BTRFS_MKCONFIG:-grub-mkconfig} -o ${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub.cfg; fi  ; done
 
 

--- a/grub-btrfsd.confd
+++ b/grub-btrfsd.confd
@@ -1,0 +1,3 @@
+# Where to locate the root snapshots
+#snapshots="/.snapshots" # Snapper in the root directory
+snapshots="/run/timeshift/backup/timeshift-btrfs/snapshots" # Timeshift

--- a/grub-btrfsd.initd
+++ b/grub-btrfsd.initd
@@ -4,6 +4,7 @@
 
 name="grub-btrfs daemon"
 command="/usr/bin/grub-btrfs-openrc"
+command_args="${snapshots}"
 pidfile="/run/{RC_SVCNAME}.pid"
 command_background=true
 


### PR DESCRIPTION
This allows users to customize the snapshots path to work with, e.g., snapper.
If no path is configured, it will default to timeshift.

Signed-off-by: David P <megver83@parabola.nu>