### PR TITLE
Fix silent update-grub failure if root FS is not supported by GRUB2

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -47,8 +47,7 @@ grub_btrfs_config="${sysconfdir}/default/grub-btrfs/config"
 if ! type btrfs >/dev/null 2>&1; then exit 0; fi # btrfs-progs isn't installed
 [[ -f "${GRUB_BTRFS_MKCONFIG_LIB:-/usr/share/grub/grub-mkconfig_lib}" ]] && . "${GRUB_BTRFS_MKCONFIG_LIB:-/usr/share/grub/grub-mkconfig_lib}" || exit 0 # grub-mkconfig_lib couldn't be found
 # Root filesystem isn't btrfs
-root_fs=$(${grub_probe} --target="fs" / 2>/dev/null)
-[[ "$root_fs" != "btrfs" ]] && exit 0
+[[ "$(${grub_probe} --target="fs" / 2>/dev/null)" != "btrfs" ]] && exit 0
 
 ## Error Handling
 print_error()


### PR DESCRIPTION
If root FS is on volume not supported by GRUB2 - `update-grub` silently fails because `snapshots-btrfs` GRUB hook silently fails at `root_fs=$(${grub_probe} --target="fs" /)` due to `set -e` at the beginning of `snapshots-btrfs`.

Failure of commands in test clause in Bash does not trigger set -v error and can be handled in script to exit gracefully - implement this.

Fixes https://github.com/Antynea/grub-btrfs/issues/222