### PR TITLE
grub-btrfs: Change syntax error message

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -597,7 +597,7 @@ submenu '${submenuname}' ${protection_authorized_users}${unrestricted_access_sub
 }
 EOF
 else
-    print_error "Syntax errors are detected in generated grub-btrfs.cfg file."
+    print_error "Syntax errors were detected in generated ${grub_directory}/grub-btrfs.new file. Old grub-btrfs.cfg (if present) was not replaced."
 fi
 
 # warn when this script is run but there is no entry in grub.cfg


### PR DESCRIPTION
I noticed that this is confusing in #230, user would search for errors in the grub-btrfs.cfg file although the old grub-btrfs.cfg file is never overwritten with grub-btrfs.new

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>