### PR TITLE
Don't display warnings when the mount command is used

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -569,7 +569,7 @@ rm -f "$grub_btrfs_directory/grub-btrfs.new"
 > "$grub_btrfs_directory/grub-btrfs.new" # Create a "grub-btrfs.new" file in "grub_btrfs_directory"
 # Create mount point then mounting
 [[ ! -d $grub_btrfs_mount_point ]] && mkdir -p "$grub_btrfs_mount_point"
-mount -o ro,subvolid=5 /dev/disk/by-uuid/"$root_uuid" "$grub_btrfs_mount_point/"
+mount -o ro,subvolid=5 /dev/disk/by-uuid/"$root_uuid" "$grub_btrfs_mount_point/" > /dev/null
 trap "unmount_grub_btrfs_mount_point" EXIT # unmounting mount point on EXIT signal
 count_warning_menuentries=0 # Count menuentries
 count_limit_snap=0 # Count snapshots


### PR DESCRIPTION
Hello.

I'm the developer of Kaisen Linux. Kaisen Linux is a distribution for sysadmins, technicians, cloud engineers... I add your tool in the BTRFS snapshots tools included on Kaisen Linux.
Since few weeks, when the mount -o command is executed to mount the temp mount point for grub-btrfs, the mount command displays a warning log to inform that systemd still uses the /etc/fstab file.
I add a patch of my grub-btrfs Debian packaging to fix that, the patch redirects all STDOUT output to /dev/null.
