### PR TITLE
Add kernel command line for snapshots as config parameter

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -92,7 +92,7 @@ grub_directory=${GRUB_BTRFS_GRUB_DIRNAME:-"/boot/grub"}
 ## Customize BOOT directory, where kernels/initrams/microcode is saved.
 boot_directory=${GRUB_BTRFS_BOOT_DIRNAME:-"/boot"}
 ## Customize GRUB-BTRFS.cfg directory, where "grub-btrfs.cfg" file is saved
-grub_btrfs_directory=${GRUB_BTRFS_GBTRFS_DIRNAME:-"/boot/grub"}
+grub_btrfs_directory=${GRUB_BTRFS_GBTRFS_DIRNAME:-${grub_directory}}
 ## Customize directory where "grub-btrfs.cfg" file is searched for by grub
 grub_btrfs_search_directory=${GRUB_BTRFS_GBTRFS_SEARCH_DIRNAME:-"\${prefix}"}
 ## Password protection management for submenu

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -121,7 +121,7 @@ boot_hs=$(${grub_probe} --device ${boot_device} --target="hints_string" 2>/dev/n
 boot_fs=$(${grub_probe} --device ${boot_device} --target="fs" 2>/dev/null) # Type filesystem of boot device
 
 ## Parameters passed to the kernel
-kernel_parameters="$GRUB_CMDLINE_LINUX $GRUB_CMDLINE_LINUX_DEFAULT"
+kernel_parameters="$GRUB_CMDLINE_LINUX $GRUB_CMDLINE_LINUX_DEFAULT $GRUB_BTRFS_SNAPSHOT_KERNEL_PARAMETERS"
 ## Mount point location
 grub_btrfs_mount_point=$(mktemp -dt grub-btrfs.XXXXXXXXXX)
 ## Class for theme

--- a/config
+++ b/config
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GRUB_BTRFS_VERSION=4.12-improve-config-2022-12-06T21:56:44+00:00
+GRUB_BTRFS_VERSION=4.12-improve-config-2022-12-06T22:10:24+00:00
 
 # Disable grub-btrfs.
 # Default: "false"

--- a/config
+++ b/config
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GRUB_BTRFS_VERSION=4.12-master-2022-12-04T21:11:00+00:00
+GRUB_BTRFS_VERSION=4.12-improve-config-2022-12-05T20:15:10+00:00
 
 # Disable grub-btrfs.
 # Default: "false"
@@ -88,7 +88,6 @@ GRUB_BTRFS_IGNORE_PREFIX_PATH=("var/lib/docker" "@var/lib/docker" "@/var/lib/doc
 #GRUB_BTRFS_OVERRIDE_BOOT_PARTITION_DETECTION="true"
 
 # Location of the folder containing the "grub.cfg" file.
-# Use by grub-btrfs to save the file "grub-btrfs.cfg".
 # Might be grub2 on some systems.
 # For example, on Fedora with EFI : "/boot/efi/EFI/fedora"
 # Default: "/boot/grub"
@@ -100,10 +99,10 @@ GRUB_BTRFS_IGNORE_PREFIX_PATH=("var/lib/docker" "@var/lib/docker" "@/var/lib/doc
 #GRUB_BTRFS_BOOT_DIRNAME="/boot"
 
 # Location where grub-btrfs.cfg should be saved.
-# Some distributions (like OpenSuSE) store those file at the snapshot directory
+# Some distributions (like OpenSuSE) store those files at the snapshot directory
 # instead of boot. Be aware that this direcory must be available for grub during
 # startup of the system.
-# Default: "/boot/grub"
+# Default: $GRUB_BTRFS_GRUB_DIRNAME
 #GRUB_BTRFS_GBTRFS_DIRNAME="/boot/grub"
 
 # Location of the directory where Grub searches for the grub-btrfs.cfg file.

--- a/config
+++ b/config
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GRUB_BTRFS_VERSION=4.12-improve-config-2022-12-05T20:15:10+00:00
+GRUB_BTRFS_VERSION=4.12-improve-config-2022-12-06T21:56:44+00:00
 
 # Disable grub-btrfs.
 # Default: "false"
@@ -47,6 +47,13 @@ GRUB_BTRFS_VERSION=4.12-improve-config-2022-12-05T20:15:10+00:00
 # If you have one or more custom microcodes, you can add them here.
 # Default: ("")
 #GRUB_BTRFS_CUSTOM_MICROCODE=("custom-ucode.img" "custom-uc.img "custom_ucode.cpio")
+
+# Additonal kernel command line parameters that should be passed to the kernel
+# when booting a snapshot.
+# For dracut based distros this could be useful to pass "rd.live.overlay.overlayfs=1"
+# or "rd.live.overlay.readonly=1" to the Kernel for booting snapshots read only.
+# Default: ""
+#GRUB_BTRFS_SNAPSHOT_KERNEL_PARAMETERS="rd.live.overlay.overlayfs=1"
 
 # Comma seperated mount options to be used when booting a snapshot.
 # They can be defined here as well as in the "/" line inside the respective snapshots'

--- a/initramfs/readme.md
+++ b/initramfs/readme.md
@@ -39,7 +39,11 @@ You notice that the name of the `hook` must match the name of the 2 installed fi
 Re-generate your initramfs  
 `mkinitcpio -P` (option -P means, all preset present in `/etc/mkinitcpio.d`)
 
+#### Dracut based distros
+Distributions that use Dracut to make their initramfs (many of the Fedora based Distros) simply have to pass either `rd.live.overlay.readonly=1` (to boot into the snapshot read only) or `rd.live.overlay.overlayfs=1` (to act like a livedisk, that is files can be changed but changes will be lost on the next boot) to their kernel command line in grub. 
+Grub-btrfs provides the variable `GRUB_BTRFS_SNAPSHOT_KERNEL_PARAMETERS` to add any command to the kernel command line. Set it to `GRUB_BTRFS_SNAPSHOT_KERNEL_PARAMETERS="rd.live.overlay.overlayfs=1"` to make snapshots immutable when booted into. 
+After changing this run `sudo /etc/grub.d/41_snapshots-btrfs` to generate a new snapshot-submenu with the parameter added. 
+
 #### Other distribution
-Refer to your distribution's documentation  
-or contribute to this project to add a paragraph.
+Refer to your distribution's documentation or contribute to this project to add a paragraph.
 #

--- a/manpages/grub-btrfs.8.man
+++ b/manpages/grub-btrfs.8.man
@@ -1,4 +1,4 @@
-.TH "grub-btrfs" "1" 
+.TH "grub-btrfs" "8"
 
 .SH "NAME"
 .PP
@@ -114,6 +114,17 @@ Example: \fCGRUB_BTRFS_NKERNEL=("kernel\-5.19.4\-custom" "vmlinux\-5.19.4\-custo
 \fCGRUB_BTRFS_NINIT=("initramfs\-5.19.4\-custom.img" "initrd\-5.19.4\-custom.img" "otherinit\-5.19.4\-custom.gz")\fP
 \fCGRUB_BTRFS_CUSTOM_MICROCODE=("custom\-ucode.img" "custom\-uc.img "custom_ucode.cpio")\fP
 
+.SS "\fCGRUB_BTRFS_SNAPSHOT_KERNEL_PARAMETERS\fP"
+.PP
+Additonal kernel command line parameters that should be passed to the kernelwhen
+booting a snapshot.
+For dracut based distros this could be useful to pass “rd.live.overlay.overlayfs=1”
+or “rd.live.overlay.readonly=1” to the Kernel for booting read only snapshots.
+.IP \(em 4
+Default: “”
+.IP \(em 4
+Example: \fCGRUB_BTRFS_SNAPSHOT_KERNEL_PARAMETERS="rd.live.overlay.overlayfs=1"\fP
+
 .SS "SNAPSHOT FILTERING"
 .SS "\fCGRUB_BTRFS_IGNORE_SPECIFIC_PATH\fP"
 .PP
@@ -168,7 +179,6 @@ Example: \fCGRUB_BTRFS_BOOT_DIRNAME="/"\fP
 .SS "\fCGRUB_BTRFS_GRUB_DIRNAME\fP"
 .PP
 Location of the folder containing the “grub.cfg” file.
-Used by grub-btrfs to save the file “grub-btrfs.cfg”.
 Might be grub2 on some systems.
 For example, on Fedora with EFI : “/boot/efi/EFI/fedora”
 .IP \(em 4
@@ -183,9 +193,13 @@ Some distributions (like OpenSuSE) store those file at the snapshot directory
 instead of boot. Be aware that this direcory must be available for grub during
 startup of the system.
 .IP \(em 4
-Default: “/boot/grub”
+Default: $GRUB\d\s-2BTRFS\s+2\u\d\s-2GRUB\s+2\u\d\s-2DIRNAME\s+2\u
 .IP \(em 4
+<<<<<<< HEAD
 Example: \fCGRUB_BTRFS_GBTRFS_DIRNAME="/.snapshots"\fP
+=======
+Example \fCGRUB_BTRFS_GBTRFS_DIRNAME="/boot/grub2"\fP
+>>>>>>> e76cdc4 (grub-btrfs: add custom kernel parameters option for snapshots)
 
 .SS "\fCGRUB_BTRFS_GBTRFS_SEARCH_DIRNAME\fP"
 .PP
@@ -203,7 +217,6 @@ NOTE: If variables of grub are used here like ${prefix}, they need to be escaped
 with `$\` before the `$`
 .IP \(em 4
 Example: GRUB\d\s-2BTRFS\s+2\u\d\s-2GBTRFS\s+2\u\d\s-2SEARCH\s+2\u\d\s-2DIRNAME\s+2\u=“\${prefix}”
-
 
 .SS "\fCGRUB_BTRFS_MKCONFIG\fP"
 .PP

--- a/manpages/grub-btrfs.8.man
+++ b/manpages/grub-btrfs.8.man
@@ -1,4 +1,4 @@
-.TH "grub-btrfs" "8"
+.TH "grub-btrfs" "1" 
 
 .SH "NAME"
 .PP
@@ -185,7 +185,7 @@ startup of the system.
 .IP \(em 4
 Default: “/boot/grub”
 .IP \(em 4
-Example GRUB\d\s-2BTRFS\s+2\u\d\s-2GBTRFS\s+2\u\d\s-2DIRNAME\s+2\u=“/boot/grub”
+Example: \fCGRUB_BTRFS_GBTRFS_DIRNAME="/.snapshots"\fP
 
 .SS "\fCGRUB_BTRFS_GBTRFS_SEARCH_DIRNAME\fP"
 .PP

--- a/manpages/grub-btrfs.8.man
+++ b/manpages/grub-btrfs.8.man
@@ -1,4 +1,4 @@
-.TH "grub-btrfs" "8"
+.TH "grub-btrfs" "8" 
 
 .SH "NAME"
 .PP
@@ -193,13 +193,9 @@ Some distributions (like OpenSuSE) store those file at the snapshot directory
 instead of boot. Be aware that this direcory must be available for grub during
 startup of the system.
 .IP \(em 4
-Default: $GRUB\d\s-2BTRFS\s+2\u\d\s-2GRUB\s+2\u\d\s-2DIRNAME\s+2\u
+Default: \fC$GRUB_BTRFS_GRUB_DIRNAME\fP
 .IP \(em 4
-<<<<<<< HEAD
 Example: \fCGRUB_BTRFS_GBTRFS_DIRNAME="/.snapshots"\fP
-=======
-Example \fCGRUB_BTRFS_GBTRFS_DIRNAME="/boot/grub2"\fP
->>>>>>> e76cdc4 (grub-btrfs: add custom kernel parameters option for snapshots)
 
 .SS "\fCGRUB_BTRFS_GBTRFS_SEARCH_DIRNAME\fP"
 .PP
@@ -216,7 +212,7 @@ NOTE: If variables of grub are used here like ${prefix}, they need to be escaped
 .PP
 with `$\` before the `$`
 .IP \(em 4
-Example: GRUB\d\s-2BTRFS\s+2\u\d\s-2GBTRFS\s+2\u\d\s-2SEARCH\s+2\u\d\s-2DIRNAME\s+2\u=“\${prefix}”
+Example: \fCGRUB_BTRFS_GBTRFS_SEARCH_DIRNAME="\${prefix}"\fP
 
 .SS "\fCGRUB_BTRFS_MKCONFIG\fP"
 .PP
@@ -256,7 +252,9 @@ and this comment \fIhttps://github.com/Antynea/grub-btrfs/issues/95#issuecomment
 Add authorized usernames separate by comma (userfoo,userbar).
 When Grub’s password protection is enabled, the superuser is authorized by default, it is not necessary to add it
 .IP \(em 4
-Default: “- Example: \fCGRUB_BTRFS_PROTECTION_AUTHORIZED_USERS="userfoo,userbar"\fP
+Default: “”
+.IP \(em 4
+Example: \fCGRUB_BTRFS_PROTECTION_AUTHORIZED_USERS="userfoo,userbar"\fP
 
 .SS "\fCGRUB_BTRFS_DISABLE_PROTECTION_SUBMENU\fP"
 .PP

--- a/manpages/grub-btrfs.8.org
+++ b/manpages/grub-btrfs.8.org
@@ -123,7 +123,6 @@ Used by "grub-btrfs" to detect the boot partition and the location of kernels, i
 
 *** ~GRUB_BTRFS_GRUB_DIRNAME~
 Location of the folder containing the "grub.cfg" file.
-Used by grub-btrfs to save the file "grub-btrfs.cfg".
 Might be grub2 on some systems.
 For example, on Fedora with EFI : "/boot/efi/EFI/fedora"
 - Default: "/boot/grub"
@@ -134,8 +133,8 @@ For example, on Fedora with EFI : "/boot/efi/EFI/fedora"
  Some distributions (like OpenSuSE) store those file at the snapshot directory
  instead of boot. Be aware that this direcory must be available for grub during
  startup of the system.
-- Default: "/boot/grub"
-- Example GRUB_BTRFS_GBTRFS_DIRNAME="/boot/grub"
+- Default: $GRUB_BTRFS_GRUB_DIRNAME
+- Example: ~GRUB_BTRFS_GBTRFS_DIRNAME="/.snapshots"~
 
 *** ~GRUB_BTRFS_GBTRFS_SEARCH_DIRNAME~
 Location of the directory where Grub searches for the grub-btrfs.cfg file.
@@ -147,7 +146,6 @@ installed. (like /boot/grub, /boot/efi/grub))
 - NOTE: If variables of grub are used here like ${prefix}, they need to be escaped
 with `\` before the `$`
 - Example: GRUB_BTRFS_GBTRFS_SEARCH_DIRNAME="\${prefix}"
-
 
 *** ~GRUB_BTRFS_MKCONFIG~
 Name/path of the command to generate the grub menu, used by "grub-btrfs.service"

--- a/manpages/grub-btrfs.8.org
+++ b/manpages/grub-btrfs.8.org
@@ -1,6 +1,6 @@
 #+title: grub-btrfs
 #+author: Pascal Jaeger
-#+man_class_option: :sectionid 8
+#+MAN_CLASS_OPTIONS: :section-id "8"
 
 * NAME
     grub-btrfs - Automatically add btrfs-Snapshots as a Grub submenu
@@ -141,7 +141,7 @@ For example, on Fedora with EFI : "/boot/efi/EFI/fedora"
  Some distributions (like OpenSuSE) store those file at the snapshot directory
  instead of boot. Be aware that this direcory must be available for grub during
  startup of the system.
-- Default: $GRUB_BTRFS_GRUB_DIRNAME
+- Default: ~$GRUB_BTRFS_GRUB_DIRNAME~
 - Example: ~GRUB_BTRFS_GBTRFS_DIRNAME="/.snapshots"~
 
 *** ~GRUB_BTRFS_GBTRFS_SEARCH_DIRNAME~
@@ -153,10 +153,13 @@ startup of the system.
 installed. (like /boot/grub, /boot/efi/grub))
 - NOTE: If variables of grub are used here like ${prefix}, they need to be escaped
 with `\` before the `$`
-- Example: GRUB_BTRFS_GBTRFS_SEARCH_DIRNAME="\${prefix}"
+- Example: ~GRUB_BTRFS_GBTRFS_SEARCH_DIRNAME="\${prefix}"~
 
 *** ~GRUB_BTRFS_MKCONFIG~
-Name/path of the command to generate the grub menu, used by "grub-btrfs.service"
+Name/path of the command to generate the grub menu, used by
+#+BEGIN_MAN
+.BR grub-btrfsd (8)
+#+END_MAN
 Might be 'grub2-mkconfig' on some systems (e.g. Fedora)
 Default paths are /sbin:/bin:/usr/sbin:/usr/bin, if your path is missing, report it on the upstream project.
 You can use the name of the command only or full the path.
@@ -183,7 +186,8 @@ Refer to the Grub documentation https://www.gnu.org/software/grub/manual/grub/gr
 and this comment https://github.com/Antynea/grub-btrfs/issues/95#issuecomment-682295660
 Add authorized usernames separate by comma (userfoo,userbar).
 When Grub's password protection is enabled, the superuser is authorized by default, it is not necessary to add it
-- Default: "- Example: ~GRUB_BTRFS_PROTECTION_AUTHORIZED_USERS="userfoo,userbar"~
+- Default: ""
+- Example: ~GRUB_BTRFS_PROTECTION_AUTHORIZED_USERS="userfoo,userbar"~
 
 *** ~GRUB_BTRFS_DISABLE_PROTECTION_SUBMENU~
 Disable authentication support for submenu of Grub-btrfs only (--unrestricted)

--- a/manpages/grub-btrfs.8.org
+++ b/manpages/grub-btrfs.8.org
@@ -83,6 +83,14 @@ Customs kernel, initramfs and microcodes that are not detected can be added in t
           ~GRUB_BTRFS_NINIT=("initramfs-5.19.4-custom.img" "initrd-5.19.4-custom.img" "otherinit-5.19.4-custom.gz")~
           ~GRUB_BTRFS_CUSTOM_MICROCODE=("custom-ucode.img" "custom-uc.img "custom_ucode.cpio")~
 
+*** ~GRUB_BTRFS_SNAPSHOT_KERNEL_PARAMETERS~
+Additonal kernel command line parameters that should be passed to the kernelwhen
+booting a snapshot.
+For dracut based distros this could be useful to pass "rd.live.overlay.overlayfs=1"
+or "rd.live.overlay.readonly=1" to the Kernel for booting read only snapshots.
+- Default: ""
+- Example: ~GRUB_BTRFS_SNAPSHOT_KERNEL_PARAMETERS="rd.live.overlay.overlayfs=1"~
+
 ** SNAPSHOT FILTERING
 
 *** ~GRUB_BTRFS_IGNORE_SPECIFIC_PATH~

--- a/manpages/grub-btrfsd.8.man
+++ b/manpages/grub-btrfsd.8.man
@@ -1,4 +1,4 @@
-.TH "grub-btrfsd" "8"
+.TH "grub-btrfsd" "8" 
 
 .SH "NAME"
 .PP

--- a/manpages/grub-btrfsd.8.org
+++ b/manpages/grub-btrfsd.8.org
@@ -1,6 +1,6 @@
 #+title: grub-btrfsd
 #+author: Pascal Jaeger
-#+man_class_option: :sectionid 8
+#+MAN_CLASS_OPTIONS: :section-id "8"
 
 * NAME
 grub-btrfsd - An OpenRC daemon to automatically update the grub menu with


### PR DESCRIPTION
See #214 and #160. 

Also improved default for GRUB_BTRFS_GBTRFS_DIRNAME to be GRUB_BTRFS_GRUB_DIRNAME (see #244)

This is completely untested, just an idea I had when reading issues. 