### PR TITLE
document & implement initramfs scripts for ubuntu

### DIFF
--- a/initramfs/readme.md
+++ b/initramfs/readme.md
@@ -39,6 +39,18 @@ You notice that the name of the `hook` must match the name of the 2 installed fi
 Re-generate your initramfs  
 `mkinitcpio -P` (option -P means, all preset present in `/etc/mkinitcpio.d`)
 
+#### Ubuntu
+1. Install initramfs scripts.
+
+	``` shell
+	sudo ./initramfs/ubuntu/setup
+	```
+2. Re-generate initramfs.
+
+	``` shell
+	sudo update-initramfs -u
+	```
+
 #### Other distribution
 Refer to your distribution's documentation  
 or contribute to this project to add a paragraph.

--- a/initramfs/ubuntu/hooks/grub-btrfs-overlay
+++ b/initramfs/ubuntu/hooks/grub-btrfs-overlay
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+PREREQ=
+prereqs() {
+	echo "$PREREQ"
+}
+case "$1" in
+	prereqs)
+		prereqs
+		exit 0
+		;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+manual_add_modules overlay

--- a/initramfs/ubuntu/hooks/grub-btrfs-overlay
+++ b/initramfs/ubuntu/hooks/grub-btrfs-overlay
@@ -12,3 +12,4 @@ esac
 
 . /usr/share/initramfs-tools/hook-functions
 manual_add_modules overlay
+copy_exec /usr/bin/findmnt /usr/bin

--- a/initramfs/ubuntu/scripts/local-bottom/grub-btrfs-overlay
+++ b/initramfs/ubuntu/scripts/local-bottom/grub-btrfs-overlay
@@ -1,30 +1,32 @@
 #!/bin/sh -e
 PREREQ=
 prereqs() {
-  echo "$PREREQ"
+	echo "$PREREQ"
 }
 case $1 in
-  prereqs)
-    prereqs
-    exit 0
-    ;;
+	prereqs)
+		prereqs
+		exit 0
+		;;
 esac
 
 . /scripts/functions
 on_err() {
-	panic 'script error'
+	log_failure_msg 'error setting up overlay'
 }
 trap on_err ERR
-if [ "$readonly" = y ]
+if [ -x /usr/bin/btrfs -a -x /usr/bin/findmnt ] &&
+		 [ "$(findmnt -no FSTYPE -M "$rootmnt")" = btrfs ] &&
+		 [ "$(btrfs property get $rootmnt ro)" != ro=false ]
 then
-	log_begin_msg 'remount read-only root as read-only layer in non-persistent, writable overlay'
-	lower_dir="$(mktemp -d -p /)"
-	ram_dir="$(mktemp -d -p /)"
+	log_begin_msg 'remount read-only subvolume as read-only layer in non-persistent, writable overlay'
+	trap log_end_msg EXIT
+	lower_dir="$(mktemp -dp /)"
+	ram_dir="$(mktemp -dp /)"
 	upper_dir="$ram_dir"/upper
 	work_dir="$ram_dir"/work
 	mount --move "$rootmnt" "$lower_dir"
 	mount -t tmpfs cowspace "$ram_dir"
 	mkdir -p "$upper_dir" "$work_dir"
 	mount -t overlay -o lowerdir="$lower_dir",upperdir="$upper_dir",workdir="$work_dir" rootfs "$rootmnt"
-	log_end_msg
 fi

--- a/initramfs/ubuntu/scripts/local-bottom/grub-btrfs-overlay
+++ b/initramfs/ubuntu/scripts/local-bottom/grub-btrfs-overlay
@@ -1,0 +1,30 @@
+#!/bin/sh -e
+PREREQ=
+prereqs() {
+  echo "$PREREQ"
+}
+case $1 in
+  prereqs)
+    prereqs
+    exit 0
+    ;;
+esac
+
+. /scripts/functions
+on_err() {
+	panic 'script error'
+}
+trap on_err ERR
+if [ "$readonly" = y ]
+then
+	log_begin_msg 'remount read-only root as read-only layer in non-persistent, writable overlay'
+	lower_dir="$(mktemp -d -p /)"
+	ram_dir="$(mktemp -d -p /)"
+	upper_dir="$ram_dir"/upper
+	work_dir="$ram_dir"/work
+	mount --move "$rootmnt" "$lower_dir"
+	mount -t tmpfs cowspace "$ram_dir"
+	mkdir -p "$upper_dir" "$work_dir"
+	mount -t overlay -o lowerdir="$lower_dir",upperdir="$upper_dir",workdir="$work_dir" rootfs "$rootmnt"
+	log_end_msg
+fi

--- a/initramfs/ubuntu/setup
+++ b/initramfs/ubuntu/setup
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd -P -- "$(dirname -- "$BASH_SOURCE")" && pwd)"
+install {"$SCRIPT_DIR",/etc/initramfs-tools}/hooks/grub-btrfs-overlay
+install {"$SCRIPT_DIR",/etc/initramfs-tools}/scripts/local-bottom/grub-btrfs-overlay


### PR DESCRIPTION
I wrote these for myself & figured others would find them useful: scripts for [initramfs-tools as documented for Ubuntu](https://manpages.ubuntu.com/manpages/bionic/en/man8/initramfs-tools.8.html).
Adapted from the Arch Linux scripts.
Tested on a VM & my workstation (both UEFI-boot enabled).
Though they might work for Debian, I haven't tested that.