### PR TITLE
Some improvements based on the use of grub-btrfs

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -569,7 +569,7 @@ rm -f "$grub_btrfs_directory/grub-btrfs.new"
 > "$grub_btrfs_directory/grub-btrfs.new" # Create a "grub-btrfs.new" file in "grub_btrfs_directory"
 # Create mount point then mounting
 [[ ! -d $grub_btrfs_mount_point ]] && mkdir -p "$grub_btrfs_mount_point"
-mount -o ro,subvolid=5 /dev/disk/by-uuid/"$root_uuid" "$grub_btrfs_mount_point/"
+mount -o ro,subvolid=5 /dev/disk/by-uuid/"$root_uuid" "$grub_btrfs_mount_point/" > /dev/null
 trap "unmount_grub_btrfs_mount_point" EXIT # unmounting mount point on EXIT signal
 count_warning_menuentries=0 # Count menuentries
 count_limit_snap=0 # Count snapshots

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -577,6 +577,16 @@ check_uuid_required
 # Detects if /boot is a separate partition
 [[ "${GRUB_BTRFS_OVERRIDE_BOOT_PARTITION_DETECTION,,}" == "true" ]] && printf "Override boot partition detection : enable \n" >&2 && boot_separate;
 if [[ "$root_uuid" != "$boot_uuid" ]] || [[ "$root_uuid_subvolume" != "$boot_uuid_subvolume" ]]; then boot_separate ; else boot_bounded ; fi
+# Make a submenu in GRUB (grub.cfg)
+cat << EOF
+if [ ! -e "\${prefix}/grub-btrfs.cfg" ]; then
+echo ""
+else
+submenu '${submenuname}' ${protection_authorized_users}${unrestricted_access_submenu}{
+    configfile "\${prefix}/grub-btrfs.cfg"
+}
+fi
+EOF
 # Show warn, menuentries exceeds 250 entries
 [[ $count_warning_menuentries -ge 250 ]] && printf "Generated %s total GRUB entries. You might experience issues loading snapshots menu in GRUB.\n" "${count_warning_menuentries}" >&2 ;
 # Show total found snapshots
@@ -587,16 +597,11 @@ fi
 if [[ "${count_limit_snap}" = "0" || -z "${count_limit_snap}" ]]; then
     print_error "No snapshots found."
 fi
-# Make a submenu in GRUB (grub.cfg) and move "grub-btrfs.new" to "grub-btrfs.cfg"
+# Move "grub-btrfs.new" to "grub-btrfs.cfg"
 header_menu
 if "${bindir}/${GRUB_BTRFS_SCRIPT_CHECK:-grub-script-check}" "$grub_btrfs_directory/grub-btrfs.new"; then
     cat "$grub_btrfs_directory/grub-btrfs.new" > "$grub_btrfs_directory/grub-btrfs.cfg"
     rm -f "$grub_btrfs_directory/grub-btrfs.new"
-    cat << EOF
-submenu '${submenuname}' ${protection_authorized_users}${unrestricted_access_submenu}{
-    configfile "${grub_btrfs_search_directory}/grub-btrfs.cfg"
-}
-EOF
 else
     print_error "Syntax errors were detected in generated ${grub_btrfs_directory}/grub-btrfs.new file. Old grub-btrfs.cfg (if present) was not replaced."
 fi

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -565,8 +565,12 @@ boot_separate()
     IFS=$oldIFS
 }
 
-rm -f "$grub_btrfs_directory/grub-btrfs.new" "$grub_btrfs_directory/grub-btrfs.cfg"
+rm -f "$grub_btrfs_directory/grub-btrfs.new"
 > "$grub_btrfs_directory/grub-btrfs.new" # Create a "grub-btrfs.new" file in "grub_btrfs_directory"
+# Create a backup of the "$grub_btrfs_directory/grub-btrfs.cfg" file if exist
+if [ -e "$grub_btrfs_directory/grub-btrfs.cfg" ]; then
+	mv -f "$grub_btrfs_directory/grub-btrfs.cfg" "$grub_btrfs_directory/grub-btrfs.cfg.bkp"
+fi
 # Create mount point then mounting
 [[ ! -d $grub_btrfs_mount_point ]] && mkdir -p "$grub_btrfs_mount_point"
 mount -o ro,subvolid=5 /dev/disk/by-uuid/"$root_uuid" "$grub_btrfs_mount_point/" > /dev/null
@@ -593,17 +597,21 @@ EOF
 if [[ "${GRUB_BTRFS_SHOW_TOTAL_SNAPSHOTS_FOUND:-"true"}" = "true" && -n "${count_limit_snap}" && "${count_limit_snap}" != "0" ]]; then
     printf "Found %s snapshot(s)\n" "${count_limit_snap}" >&2 ;
 fi
-# if no snapshot found, exit
+# if no snapshot found, delete the "$grub_btrfs_directory/grub-btrfs.new" file and the "$grub_btrfs_directory/grub-btrfs.cfg.bkp" file and exit
 if [[ "${count_limit_snap}" = "0" || -z "${count_limit_snap}" ]]; then
+    rm -f "$grub_btrfs_directory/grub-btrfs.new" "$grub_btrfs_directory/grub-btrfs.cfg.bkp"
     print_error "No snapshots found."
 fi
 # Move "grub-btrfs.new" to "grub-btrfs.cfg"
 header_menu
 if "${bindir}/${GRUB_BTRFS_SCRIPT_CHECK:-grub-script-check}" "$grub_btrfs_directory/grub-btrfs.new"; then
     cat "$grub_btrfs_directory/grub-btrfs.new" > "$grub_btrfs_directory/grub-btrfs.cfg"
-    rm -f "$grub_btrfs_directory/grub-btrfs.new"
+    rm -f "$grub_btrfs_directory/grub-btrfs.new" "$grub_btrfs_directory/grub-btrfs.cfg.bkp"
 else
-    print_error "Syntax errors were detected in generated ${grub_btrfs_directory}/grub-btrfs.new file. Old grub-btrfs.cfg (if present) was not replaced."
+if [ -e "$grub_btrfs_directory/grub-btrfs.cfg.bkp" ]; then
+        mv -f "$grub_btrfs_directory/grub-btrfs.cfg.bkp" "$grub_btrfs_directory/grub-btrfs.cfg"
+fi
+	print_error "Syntax errors were detected in generated ${grub_btrfs_directory}/grub-btrfs.new file. The old grub-btrfs.cfg file (if present) have been restored."
 fi
 
 # warn when this script is run but there is no entry in grub.cfg

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -565,7 +565,7 @@ boot_separate()
     IFS=$oldIFS
 }
 
-rm -f "$grub_btrfs_directory/grub-btrfs.new"
+rm -f "$grub_btrfs_directory/grub-btrfs.new" "$grub_btrfs_directory/grub-btrfs.cfg"
 > "$grub_btrfs_directory/grub-btrfs.new" # Create a "grub-btrfs.new" file in "grub_btrfs_directory"
 # Create mount point then mounting
 [[ ! -d $grub_btrfs_mount_point ]] && mkdir -p "$grub_btrfs_mount_point"

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ MAN_DIR = $(SHARE_DIR)/man
 
 TEMP_DIR = ./temp
 
+BOOT_DIR = /boot/grub
+
 .PHONY: install uninstall clean help
 
 install:
@@ -63,8 +65,9 @@ install:
 	@install -Dm644 -t "$(SHARE_DIR)/doc/$(PKGNAME)/" README.md
 	@install -Dm644 "initramfs/readme.md" "$(SHARE_DIR)/doc/$(PKGNAME)/initramfs-overlayfs.md"
 	@rm -rf "${TEMP_DIR}"
-	@if command -v grub-mkconfig; then \
-		grub-mkconfig -o /boot/grub/grub.cfg; \
+	@if command -v grub-mkconfig > /dev/null; then \
+		echo "Updating the GRUB menu..."; \
+		grub-mkconfig -o "$(BOOT_DIR)/grub.cfg"; \
 	 fi
 
 uninstall:
@@ -97,6 +100,10 @@ uninstall:
 	@rmdir --ignore-fail-on-non-empty "$(SHARE_DIR)/doc/$(PKGNAME)/" || :
 	@rmdir --ignore-fail-on-non-empty "$(SHARE_DIR)/licenses/$(PKGNAME)/" || :
 	@rmdir --ignore-fail-on-non-empty "$(DESTDIR)/etc/default/grub-btrfs" || :
+	@if command -v grub-mkconfig > /dev/null; then \
+                echo "Updating the GRUB menu..."; \
+                grub-mkconfig -o "$(BOOT_DIR)/grub.cfg"; \
+         fi
 
 clean:
 	@echo "Deleting ./temp"
@@ -115,6 +122,7 @@ help:
 	@echo "  ----------+------+--------------------------------+----------------------------"
 	@echo "  DESTDIR   | path | install destination            | <unset>"
 	@echo "  PREFIX    | path | system tree prefix             | '/usr'"
+	@echo "  BOOT_DIR  | path | boot data location             | '/boot/grub'"
 	@echo "  SHARE_DIR | path | shared data location           | '\$$(DESTDIR)\$$(PREFIX)/share'"
 	@echo "  LIB_DIR   | path | system libraries location      | '\$$(DESTDIR)\$$(PREFIX)/lib'"
 	@echo "  PKGNAME   | name | name of the ditributed package | 'grub-btrfs'"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ INITCPIO ?= false
 SYSTEMD ?= true
 OPENRC ?= false
 
+BOOT_DIR_DEBIAN ?= /boot/grub
+BOOT_DIR_FEDORA ?= /boot/grub2
+
+GRUB_UPDATE_EXCLUDE ?= false
+
 SHARE_DIR = $(DESTDIR)$(PREFIX)/share
 LIB_DIR = $(DESTDIR)$(PREFIX)/lib
 BIN_DIR = $(DESTDIR)$(PREFIX)/bin
@@ -12,8 +17,6 @@ MAN_DIR = $(SHARE_DIR)/man
 
 TEMP_DIR = ./temp
 
-BOOT_DIR_DEBIAN = /boot/grub
-BOOT_DIR_FEDORA = /boot/grub2
 
 .PHONY: install uninstall clean help
 
@@ -66,11 +69,11 @@ install:
 	@install -Dm644 -t "$(SHARE_DIR)/doc/$(PKGNAME)/" README.md
 	@install -Dm644 "initramfs/readme.md" "$(SHARE_DIR)/doc/$(PKGNAME)/initramfs-overlayfs.md"
 	@rm -rf "${TEMP_DIR}"
-	@if command -v grub-mkconfig > /dev/null && [ -e "$(BOOT_DIR_DEBIAN)/grub.cfg" ]; then \
+	@if command -v grub-mkconfig > /dev/null && [ -e "$(BOOT_DIR_DEBIAN)/grub.cfg" ] && test "$(GRUB_UPDATE_EXCLUDE)" = false; then \
 		echo "Updating the GRUB menu..."; \
 		grub-mkconfig -o "$(BOOT_DIR_DEBIAN)/grub.cfg"; \
 	 fi
-	@if command -v grub2-mkconfig > /dev/null && [ -e "$(BOOT_DIR_FEDORA)/grub.cfg" ]; then \
+	@if command -v grub2-mkconfig > /dev/null && [ -e "$(BOOT_DIR_FEDORA)/grub.cfg" ] && test "$(GRUB_UPDATE_EXCLUDE)" = false; then \
 		echo "Updating the GRUB menu..."; \
 		grub2-mkconfig -o "$(BOOT_DIR_FEDORA)/grub.cfg"; \
 	fi
@@ -105,11 +108,11 @@ uninstall:
 	@rmdir --ignore-fail-on-non-empty "$(SHARE_DIR)/doc/$(PKGNAME)/" || :
 	@rmdir --ignore-fail-on-non-empty "$(SHARE_DIR)/licenses/$(PKGNAME)/" || :
 	@rmdir --ignore-fail-on-non-empty "$(DESTDIR)/etc/default/grub-btrfs" || :
-	@if command -v grub-mkconfig > /dev/null && [ -e "$(BOOT_DIR_DEBIAN)/grub.cfg" ]; then \
+	@if command -v grub-mkconfig > /dev/null && [ -e "$(BOOT_DIR_DEBIAN)/grub.cfg" ] && test "$(GRUB_UPDATE_EXCLUDE)" = false; then \
                 echo "Updating the GRUB menu..."; \
                 grub-mkconfig -o "$(BOOT_DIR_DEBIAN)/grub.cfg"; \
          fi
-	@if command -v grub2-mkconfig > /dev/null && [ -e "$(BOOT_DIR_FEDORA)/grub.cfg" ]; then \
+	@if command -v grub2-mkconfig > /dev/null && [ -e "$(BOOT_DIR_FEDORA)/grub.cfg" ] && test "$(GRUB_UPDATE_EXCLUDE)" = false; then \
 		echo "Updating the GRUB menu..."; \
 		grub2-mkconfig -o "$(BOOT_DIR_FEDORA)/grub.cfg"; \
 	fi
@@ -127,16 +130,17 @@ help:
 	@echo "           uninstall"
 	@echo "           help"
 	@echo
-	@echo "  parameter | type | description                    | defaults"
-	@echo "  ----------+------+--------------------------------+----------------------------"
-	@echo "  DESTDIR          | path | install destination                                   | <unset>"
-	@echo "  PREFIX           | path | system tree prefix                                    | '/usr'"
-	@echo "  BOOT_DIR_DEBIAN  | path | boot data location (Debian, Ubuntu, Gentoo, Arch...)  | '/boot/grub'"
-	@echo "  BOOT_DIR_FEDORA  | path | boot data location (Fedora, RHEL, CentOS, Rocky...)   | '/boot/grub2'"
-	@echo "  SHARE_DIR        | path | shared data location                                  | '\$$(DESTDIR)\$$(PREFIX)/share'"
-	@echo "  LIB_DIR          | path | system libraries location                             | '\$$(DESTDIR)\$$(PREFIX)/lib'"
-	@echo "  PKGNAME          | name | name of the ditributed package                        | 'grub-btrfs'"
-	@echo "  INITCPIO         | bool | include mkinitcpio hook                               | false"
-	@echo "  SYSTEMD          | bool | include unit files                                    | true"
-	@echo "  OPENRC           | bool | include OpenRc daemon                                 | false"
+	@echo "  parameter           | type | description                                           | defaults"
+	@echo "  --------------------+------+-------------------------------------------------------+----------------------------"
+	@echo "  DESTDIR             | path | install destination                                   | <unset>"
+	@echo "  PREFIX              | path | system tree prefix                                    | '/usr'"
+	@echo "  BOOT_DIR_DEBIAN     | path | boot data location (Debian, Ubuntu, Gentoo, Arch...)  | '/boot/grub'"
+	@echo "  BOOT_DIR_FEDORA     | path | boot data location (Fedora, RHEL, CentOS, Rocky...)   | '/boot/grub2'"
+	@echo "  SHARE_DIR           | path | shared data location                                  | '\$$(DESTDIR)\$$(PREFIX)/share'"
+	@echo "  LIB_DIR             | path | system libraries location                             | '\$$(DESTDIR)\$$(PREFIX)/lib'"
+	@echo "  PKGNAME             | name | name of the ditributed package                        | 'grub-btrfs'"
+	@echo "  INITCPIO            | bool | include mkinitcpio hook                               | false"
+	@echo "  SYSTEMD             | bool | include unit files                                    | true"
+	@echo "  OPENRC              | bool | include OpenRc daemon                                 | false"
+	@echo "  GRUB_UPDATE_EXCLUDE | bool | Do not update grub after installation                 | false"
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,9 @@ install:
 	@install -Dm644 -t "$(SHARE_DIR)/doc/$(PKGNAME)/" README.md
 	@install -Dm644 "initramfs/readme.md" "$(SHARE_DIR)/doc/$(PKGNAME)/initramfs-overlayfs.md"
 	@rm -rf "${TEMP_DIR}"
+	@if command -v grub-mkconfig; then \
+		grub-mkconfig -o /boot/grub/grub.cfg; \
+	 fi
 
 uninstall:
 	@echo "Uninstalling grub-btrfs"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ MAN_DIR = $(SHARE_DIR)/man
 
 TEMP_DIR = ./temp
 
-BOOT_DIR = /boot/grub
+BOOT_DIR_DEBIAN = /boot/grub
+BOOT_DIR_FEDORA = /boot/grub2
 
 .PHONY: install uninstall clean help
 
@@ -65,10 +66,14 @@ install:
 	@install -Dm644 -t "$(SHARE_DIR)/doc/$(PKGNAME)/" README.md
 	@install -Dm644 "initramfs/readme.md" "$(SHARE_DIR)/doc/$(PKGNAME)/initramfs-overlayfs.md"
 	@rm -rf "${TEMP_DIR}"
-	@if command -v grub-mkconfig > /dev/null; then \
+	@if command -v grub-mkconfig > /dev/null && [ -e "$(BOOT_DIR_DEBIAN)/grub.cfg" ]; then \
 		echo "Updating the GRUB menu..."; \
-		grub-mkconfig -o "$(BOOT_DIR)/grub.cfg"; \
+		grub-mkconfig -o "$(BOOT_DIR_DEBIAN)/grub.cfg"; \
 	 fi
+	@if command -v grub2-mkconfig > /dev/null && [ -e "$(BOOT_DIR_FEDORA)/grub.cfg" ]; then \
+		echo "Updating the GRUB menu..."; \
+		grub2-mkconfig -o "$(BOOT_DIR_FEDORA)/grub.cfg"; \
+	fi
 
 uninstall:
 	@echo "Uninstalling grub-btrfs"
@@ -100,10 +105,14 @@ uninstall:
 	@rmdir --ignore-fail-on-non-empty "$(SHARE_DIR)/doc/$(PKGNAME)/" || :
 	@rmdir --ignore-fail-on-non-empty "$(SHARE_DIR)/licenses/$(PKGNAME)/" || :
 	@rmdir --ignore-fail-on-non-empty "$(DESTDIR)/etc/default/grub-btrfs" || :
-	@if command -v grub-mkconfig > /dev/null; then \
+	@if command -v grub-mkconfig > /dev/null && [ -e "$(BOOT_DIR_DEBIAN)/grub.cfg" ]; then \
                 echo "Updating the GRUB menu..."; \
-                grub-mkconfig -o "$(BOOT_DIR)/grub.cfg"; \
+                grub-mkconfig -o "$(BOOT_DIR_DEBIAN)/grub.cfg"; \
          fi
+	@if command -v grub2-mkconfig > /dev/null && [ -e "$(BOOT_DIR_FEDORA)/grub.cfg" ]; then \
+		echo "Updating the GRUB menu..."; \
+		grub2-mkconfig -o "$(BOOT_DIR_FEDORA)/grub.cfg"; \
+	fi
 
 clean:
 	@echo "Deleting ./temp"
@@ -120,13 +129,14 @@ help:
 	@echo
 	@echo "  parameter | type | description                    | defaults"
 	@echo "  ----------+------+--------------------------------+----------------------------"
-	@echo "  DESTDIR   | path | install destination            | <unset>"
-	@echo "  PREFIX    | path | system tree prefix             | '/usr'"
-	@echo "  BOOT_DIR  | path | boot data location             | '/boot/grub'"
-	@echo "  SHARE_DIR | path | shared data location           | '\$$(DESTDIR)\$$(PREFIX)/share'"
-	@echo "  LIB_DIR   | path | system libraries location      | '\$$(DESTDIR)\$$(PREFIX)/lib'"
-	@echo "  PKGNAME   | name | name of the ditributed package | 'grub-btrfs'"
-	@echo "  INITCPIO  | bool | include mkinitcpio hook        | false"
-	@echo "  SYSTEMD   | bool | include unit files             | true"
-	@echo "  OPENRC    | bool | include OpenRc daemon          | false"
+	@echo "  DESTDIR          | path | install destination                                   | <unset>"
+	@echo "  PREFIX           | path | system tree prefix                                    | '/usr'"
+	@echo "  BOOT_DIR_DEBIAN  | path | boot data location (Debian, Ubuntu, Gentoo, Arch...)  | '/boot/grub'"
+	@echo "  BOOT_DIR_FEDORA  | path | boot data location (Fedora, RHEL, CentOS, Rocky...)   | '/boot/grub2'"
+	@echo "  SHARE_DIR        | path | shared data location                                  | '\$$(DESTDIR)\$$(PREFIX)/share'"
+	@echo "  LIB_DIR          | path | system libraries location                             | '\$$(DESTDIR)\$$(PREFIX)/lib'"
+	@echo "  PKGNAME          | name | name of the ditributed package                        | 'grub-btrfs'"
+	@echo "  INITCPIO         | bool | include mkinitcpio hook                               | false"
+	@echo "  SYSTEMD          | bool | include unit files                                    | true"
+	@echo "  OPENRC           | bool | include OpenRc daemon                                 | false"
 	@echo

--- a/grub-btrfsd
+++ b/grub-btrfsd
@@ -203,19 +203,12 @@ fi
 create_grub_menu() {
     #  create the grub submenu of the whole grub menu, depending on wether the submenu already exists
     #  and gives feedback if it worked
-    if [ -s "${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then
-        if /etc/grub.d/41_snapshots-btrfs; then
+    if [ -x "/etc/grub.d/41_snapshots-btrfs" ]; then
+        /etc/grub.d/41_snapshots-btrfs
 			log "Grub submenu recreated" "${GREEN}"
         else
 			err "[!] Error during grub submenu creation (grub-btrfs error)" "${RED}"
         fi
-    else
-        if ${GRUB_BTRFS_MKCONFIG:-grub-mkconfig} -o ${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub.cfg; then
-            log "Grub menu recreated" "${GREEN}"
-        else
-            err "[!] Error during grub menu creation (grub/ grub-btrfs error)" "${RED}"
-        fi
-    fi
 }
 
 set_snapshot_dir() {

--- a/grub-btrfsd
+++ b/grub-btrfsd
@@ -203,12 +203,19 @@ fi
 create_grub_menu() {
     #  create the grub submenu of the whole grub menu, depending on wether the submenu already exists
     #  and gives feedback if it worked
-    if [ -x "/etc/grub.d/41_snapshots-btrfs" ]; then
-        /etc/grub.d/41_snapshots-btrfs
-			log "Grub submenu recreated" "${GREEN}"
+    if grep "snapshots-btrfs" "{grub_directory}/grub.cfg"; then
+    	if  /etc/grub.d/41_snapshots-btrfs; then 
+		log "Grub submenu recreated" "${GREEN}"
         else
-			err "[!] Error during grub submenu creation (grub-btrfs error)" "${RED}"
+		err "[!] Error during grub submenu creation (grub-btrfs error)" "${RED}"
         fi
+    else
+        if ${GRUB_BTRFS_MKCONFIG:-grub-mkconfig} -o ${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub.cfg; then
+		log "Grub menu recreated" "${GREEN}"
+	else
+		err "[!] Error during grub menu creation (grub/ grub-btrfs error)" "${RED}"
+	fi
+    fi
 }
 
 set_snapshot_dir() {


### PR DESCRIPTION
Hello the team,

I hope you are well.

When using grub-btrfs and the integration I did previously on Kaisen Linux, caused me some important bugs (detailed below).

I have reviewed my integration and offer you some code improvements:

- Removal of grub-btrfs.cfg also when grub-btrfs.new is deleted (if no snapshot exists, why keep the file? Moreover, even if all snapshots are deleted, the file still keeps some snapshots that can't be booted, thus creating false entries, this scenario works on Debian (for my part tested on Kaisen Linux 2.2) when only the script /etc/grub.d/41_snapshots-btrfs is executed and not the command grub-mkconfig -o /boot/grub/grub.cfg). Commit: https://github.com/kevinchevreuil/grub-btrfs/commit/9118c43c598666c35e36aab83d095c3523d8c65b

- Creation of an if statement to no longer display the BTRFS snapshots menu if the file /boot/grub/grub-btrfs.cfg does not exist (if no snapshot exists, it will not be created, in connection with the first proposal). This menu does disappear when the grub-mkconfig -o /boot/grub/grub.cfg command is executed, but not the /etc/grub.d/41_snapshots-btrfs script alone, causing an invalid entry. In connection with the previous commit, it fixes this problem, and allows to execute only the script alone without creating an invalid GRUB entry. Commit: https://github.com/kevinchevreuil/grub-btrfs/commit/a705b06cff758db788ce02d5d690a4a322135e90

- The grub-btrfsd script on the create_grub_menu function only executes the /etc/grub.d/41_snapshots-btrfs script in connection with the previous commits. Commit: https://github.com/kevinchevreuil/grub-btrfs/commit/1b6a9d44a19f0a06de2c8aa78f29ea054d2a763c

- I added to the Makefile an if statement to run an update of GRUB when installing and uninstalling grub-btrfs. This allows to add at the installation of grub-btrfs the condition to display BTRFS snapshots in the menu if they exist in connection with the previous commits or to remove them from GRUB if the program is uninstalled. This thing is also done on my default Debian package. I'm trying to enforce this behavior for a standard installation without package. Commits: https://github.com/kevinchevreuil/grub-btrfs/commit/a58b6cbb5a4ed4ad19311fdc7eb00e4b7d5bb43a and https://github.com/kevinchevreuil/grub-btrfs/commit/263cc1ddf9279a1e4231feb60d581db9a884ba57

The reason why I suggest these improvements is related to the integration of grub-btrfs in Kaisen Linux via my Debian package. I was running the grub-mkconfig -o /boot/grub/grub.cfg command and not the standalone script. All this was coupled with a systemd .path and .service unit file (.path checking the /run/timeshift directory), precisely to "fix" this problem. I found the same problems (invalid GRUB entries) when using the grub-btrfsd daemon since 4.12. Except that when using grub-btrfs to restore snapshots, the grub menu was completely updated and changed the GRUB entry of Kaisen by the path of the snapshot... If this one is deleted, the system becomes "impossible" to boot, and especially, it is not the good sub-volume which is used after the restoration of a snapshot...
Indeed, launching only the /etc/grub.d/41_snapshots-btrfs script worked, but left invalid GRUB entries. Since 4.12, if the GRUB update was not done before or the /boot/rub/grub-btrfs.cfg file is empty, the whole grub menu is updated, which can be problematic in some specific use cases, for example if you want to have a fully dynamic GRUB menu without regenerating the whole configuration each time (or to limit the various problems linked to snapshots startups and/or users behaviors).

If these proposals are accepted, how about creating a 4.12.1 or 4.13 release (at your convenience), so that I can redistribute these default fixes in the unpatched code on my Debian package as well as to allow potential other maintainers of grub-btrfs on a distribution to integrate the latest default fixes?
