### PR TITLE
Fix path_snapshot command in 41_snapshots-btrfs so snapshot discovery works again for Debian and Ubuntu users

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -298,7 +298,7 @@ snapshot_list()
     for snap in $(btrfs subvolume list -sa "${btrfs_subvolume_sort}" /); do # Parse btrfs snapshots
         IFS=$oldIFS
         snap=("${snap}")
-        local path_snapshot=${snap[@]:13:${#snap[@]}}
+        local path_snapshot=$(echo "${snap}" | awk '{print $NF}')
         if [ "$path_snapshot" = "DELETED" ]; then continue; fi # Discard deleted snapshots
         [[ ${path_snapshot%%"/"*} == "<FS_TREE>" ]] && path_snapshot=${path_snapshot#*"/"} # Remove the "<FS_TREE>" string at the beginning of the path
 


### PR DESCRIPTION
This commit is a fix for 41_snapshots-btrfs as suggested by @kamkarthi https://github.com/Antynea/grub-btrfs/issues/256.

It fixes 41_snapshots-btrfs's discovery of snapshots under Debian and Ubuntu.