### PR TITLE
add support for yabsnap snapshot information

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -320,7 +320,7 @@ snapshot_list()
         local description_snapshot="N/A"
         
         # path to yabsnap snapshot meta data
-        local yabsnap_info="$grub_btrfs_mount_point/${path_snapshot%"/"*}/$(echo "${snap[@]:13:1}" | awk -F'/' '{print $3 "-meta.json"}')"
+        local yabsnap_info="$grub_btrfs_mount_point/${path_snapshot%"/"*}/$(echo "${snap[13]}" | awk -F'/' '{print $3 "-meta.json"}')"
 
         if [[ -s "$grub_btrfs_mount_point/${path_snapshot%"/"*}/$snapper_info" ]] ; then
             type_snapshot=$(awk -F"<|>" 'match($2, /^type/) {print $3}' "$grub_btrfs_mount_point/${path_snapshot%"/"*}/$snapper_info") # search matching string beginning "type"

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -315,7 +315,7 @@ snapshot_list()
         fi
         [ ! -d "$grub_btrfs_mount_point/$path_snapshot/boot" ] && continue; # Discard snapshots without /boot folder
 
-        # Parse Snapper & timeshift & yabsnap informations
+        # Parse Snapper & timeshift & yabsnap information
         local type_snapshot="N/A"
         local description_snapshot="N/A"
         

--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -315,16 +315,24 @@ snapshot_list()
         fi
         [[ ! -d "$grub_btrfs_mount_point/$path_snapshot/boot" ]] && continue; # Discard snapshots without /boot folder
 
-        # Parse Snapper & timeshift information
+        # Parse Snapper & timeshift & yabsnap informations
         local type_snapshot="N/A"
         local description_snapshot="N/A"
+        
+        # path to yabsnap snapshot meta data
+        local yabsnap_info="$grub_btrfs_mount_point/${path_snapshot%"/"*}/$(echo "${snap[@]:13:1}" | awk -F'/' '{print $3 "-meta.json"}')"
+
         if [[ -s "$grub_btrfs_mount_point/${path_snapshot%"/"*}/$snapper_info" ]] ; then
             type_snapshot=$(awk -F"<|>" 'match($2, /^type/) {print $3}' "$grub_btrfs_mount_point/${path_snapshot%"/"*}/$snapper_info") # search matching string beginning "type"
             description_snapshot=$(awk -F"<|>" 'match($2, /^description/) {print $3}' "$grub_btrfs_mount_point/${path_snapshot%"/"*}/$snapper_info") # search matching string beginning "description"
         elif [[ -s "$grub_btrfs_mount_point/${path_snapshot%"/"*}/$timeshift_info" ]] ; then
             type_snapshot=$(awk -F" : " 'match($1, /^[ \t]+"tags"/) {gsub(/"|,/,"");print $2}' "$grub_btrfs_mount_point/${path_snapshot%"/"*}/$timeshift_info") # search matching string beginning "tags"
             description_snapshot=$(awk -F" : " 'match($1, /^[ \t]+"comments"/) {gsub(/"|,/,"");print $2}' "$grub_btrfs_mount_point/${path_snapshot%"/"*}/$timeshift_info") # search matching string beginning "comments"
+        elif [[ -s $yabsnap_info ]] ; then
+            type_snapshot=$(grep -P '^\s*"trigger"' $yabsnap_info | awk -F'"' '{print $4}') # search matching string beginning "trigger"
+            description_snapshot=$(grep -P '^\s*"comment"' $yabsnap_info | awk -F'"' '{print $4}') # search matching string beginning "comment"
         fi
+
         [[ -z "$type_snapshot" ]] && type_snapshot=("N/A")
         [[ -z "$description_snapshot" ]] && description_snapshot=("N/A")
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ### 🔎 Description:
 grub-btrfs improves the grub bootloader by adding a btrfs snapshots sub-menu, allowing the user to boot into snapshots.
 
-grub-btrfs supports manual snapshots as well as snapper and timeshift created snapshots.
+grub-btrfs supports manual snapshots as well as snapper, timeshift, and yabsnap created snapshots.
 
 ##### Warning: booting read-only snapshots can be tricky
 
@@ -25,7 +25,7 @@ Refer to the [documentation](https://github.com/Antynea/grub-btrfs/blob/master/i
 * Automatically detect if `/boot` is in a separate partition.
 * Automatically detect kernel, initramfs and Intel/AMD microcode in `/boot` directory within snapshots.
 * Automatically create corresponding menu entries in `grub.cfg`
-* Automatically detect the type/tags and descriptions/comments of Snapper/Timeshift snapshots.
+* Automatically detect the type/tags/triggers and descriptions/comments of Snapper/Timeshift/Yabsnap snapshots.
 * Automatically generate `grub.cfg` if you use the provided Systemd/ OpenRC service.
 
 - - -
@@ -97,7 +97,7 @@ The daemon can be configured by passing different command line arguments to it.
 The available arguments are:
 * `SNAPSHOTS_DIRS`
 This argument specifies the (space separated) paths where grub-btrfsd looks for newly created snapshots and snapshot deletions. It is usually defined by the program used to make snapshots.
-E.g. for Snapper this would be `/.snapshots`. It is possible to define more than one directory here, all directories will inherit the same settings (recursive etc.).
+E.g. for Snapper or Yabsnap this would be `/.snapshots`. It is possible to define more than one directory here, all directories will inherit the same settings (recursive etc.).
 This argument is not necessary to provide if `--timeshift-auto` is set. 
 * `-c / --no-color`
 Disable colors in output.
@@ -118,7 +118,7 @@ Displays a short help message.
 ### 🪀 Automatically update grub upon snapshot creation or deletion
 Grub-btrfsd is a daemon that watches the snapshot directory for you and updates the grub menu automatically every time a snapshot is created or deleted.
 By default this daemon watches the directory `/.snapshots` for changes (creation or deletion of snapshots) and triggers the grub menu creation and re-installation of grub if any changes are noticed.
-Therefore, if Snapper is used with its default directory, the daemon can just be started and nothing needs to be configured. See the instructions below to configure grub-btrfsd for use with Timeshift or when using an alternative snapshots directory with Snapper.
+Therefore, if Snapper or Yabsnap is used with its default directory, the daemon can just be started and nothing needs to be configured. See the instructions below to configure grub-btrfsd for use with Timeshift or when using an alternative snapshots directory with Snapper/Yabsnap.
 - - - 
 #### grub-btrfsd systemd instructions
 To start the daemon run:
@@ -294,7 +294,7 @@ If you have problems with the daemon, you can run it with the `--verbose`-flag. 
 ``` bash
 sudo /usr/bin/grub-btrfsd --verbose --timeshift-auto` (for timeshift)
 # or 
-sudo /usr/bin/grub-btrfsd /.snapshots --verbose` (for snapper)
+sudo /usr/bin/grub-btrfsd /.snapshots --verbose` (for snapper/yabsnap)
 ```
 Or pass `--verbose` to the daemon using the Systemd .service file or the OpenRC conf.d file respectively.
 

--- a/config
+++ b/config
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 
-GRUB_BTRFS_VERSION=4.13-fix_bashism-2024-03-06T13:23:26+00:00
+GRUB_BTRFS_VERSION=4.13-yabsnap_info_support-2024-03-06T13:43:57+00:00
 
 # Disable grub-btrfs.
 # Default: "false"

--- a/config
+++ b/config
@@ -81,6 +81,8 @@ GRUB_BTRFS_IGNORE_PREFIX_PATH=("var/lib/docker" "@var/lib/docker" "@/var/lib/doc
 # Type = single, pre, post.
 # For Timeshift:
 # Tag = boot, ondemand, hourly, daily, weekly, monthly.
+# For yabsnap:
+# Trigger = S, I, U.
 # Default: ("")
 #GRUB_BTRFS_IGNORE_SNAPSHOT_TYPE=("")
 


### PR DESCRIPTION
[Yabsnap](https://github.com/hirak99/yabsnap) is equivalent to OpenSUSE's snapper but made for Arch Linux

This PR adds support for parsing the information from the json metadata files that yabsnap uses to track comments and triggers (type). There is no set name for the metadata files, its just the name of the snapshot + "-meta.json", and the files are located in the same directory where its respective snapshot lives