### PR TITLE
Add support for GRUB patches from SUSE

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -224,7 +224,12 @@ make_menu_entries()
             search --no-floppy --fs-uuid  --set=root ${boot_hs} ${boot_uuid}
         else
             search --no-floppy --fs-uuid  --set=root ${boot_uuid}
+        fi"
+        if [ "${SUSE_BTRFS_SNAPSHOT_BOOTING:-"false"}" = "true" ]; then
+            entry "\
+        set btrfs_subvolid=5"
         fi
+        entry "\
         echo 'Loading Snapshot: "${snap_date_trim}" "${snap_dir_name_trim}"'
         echo 'Loading Kernel: "${k}" ...'
         linux \"${boot_dir_root_grub}/"${k}"\" root="${LINUX_ROOT_DEVICE}" ${kernel_parameters} ${rootflags}subvol=\""${snap_dir_name_trim}"\""
@@ -259,7 +264,12 @@ make_menu_entries()
             search --no-floppy --fs-uuid  --set=root ${boot_hs} ${boot_uuid}
         else
             search --no-floppy --fs-uuid  --set=root ${boot_uuid}
+        fi"
+        if [ "${SUSE_BTRFS_SNAPSHOT_BOOTING:-"false"}" = "true" ]; then
+            entry "\
+        set btrfs_subvolid=5"
         fi
+        entry "\
         echo 'Loading Snapshot: "${snap_date_trim}" "${snap_dir_name_trim}"'
         echo 'Loading Kernel: "${k}" ...'
         linux \"${boot_dir_root_grub}/"${k}"\" root="${LINUX_ROOT_DEVICE}" ${kernel_parameters} ${rootflags}subvol=\""${snap_dir_name_trim}"\""


### PR DESCRIPTION
Some GRUBs out there (Fedora, openSUSE) have an option that makes all paths relative to the default subvolume of the filesystem. This can be used to include /boot in your snapshots and roll them back without having to regenerate grub.cfg.

However, enabling that option will break grub-btrfs, because loading the kernel from a different snapshot requires the paths to be absolute. To make this work, GRUB has to be told explicitly to access the root subvolume when booting to a snapshot.

I hope this is acceptable, because it's essentially a workaround for a downstream patch of GRUB. 