### PR TITLE
Respect GRUB_DISABLE_LINUX_PARTUUID setting

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -151,7 +151,9 @@ CLASS="--class snapshots --class gnu-linux --class gnu --class os"
 oldIFS=$IFS
 ## Detect uuid requirement (lvm,btrfs...)
 check_uuid_required() {
-if [ "${root_uuid}" = "" ] || [ "${GRUB_DISABLE_LINUX_UUID}" = "true" ] \
+if [ "${GRUB_DISABLE_LINUX_PARTUUID}" = "false" ]; then
+    LINUX_ROOT_DEVICE=PARTUUID=$(${grub_probe} --device "${root_device}" --target=partuuid 2>/dev/null)
+elif [ "${root_uuid}" = "" ] || [ "${GRUB_DISABLE_LINUX_UUID}" = "true" ] \
     || ! test -e "/dev/disk/by-uuid/${root_uuid}" \
     || ( test -e "${root_device}" && uses_abstraction "${root_device}" lvm ); then
     LINUX_ROOT_DEVICE=${root_device}


### PR DESCRIPTION
Note that `grub-mkconfig` uses `PARTUUID` even if the setting `GRUB_DISABLE_LINUX_UUUID=true` is not specified. It is sufficient only to specify the setting `GRUB_DISABLE_LINUX_PARTUUID=false`. At least that's how it works on my system (gentoo). Here is an excerpt from the `grub-mkconfig` documentation:

> If ‘grub-mkconfig’ cannot identify the root filesystem via its
     universally-unique indentifier (UUID), ‘grub-mkconfig’ can use the
     UUID of the partition containing the filesystem to identify the
     root filesystem to the Linux kernel via a ‘root=PARTUUID=...’
     kernel parameter.  This is not as reliable as using the filesystem
     UUID, but is more reliable than using the Linux device names.  When
     ‘GRUB_DISABLE_LINUX_PARTUUID’ is set to ‘false’, the Linux kernel
     version must be 2.6.37 (3.10 for systems using the MSDOS partition
     scheme) or newer.  This option defaults to ‘true’.  To enable the
     use of partition UUIDs, set this option to ‘false’.