### PR TITLE
[BUGFIX] Use correct bin path in the systemd service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ install:
 	@# Systemd init system
 	@if test "$(SYSTEMD)" = true; then \
 		echo "Installing systemd .service file"; \
-		install -Dm644 -t "$(LIB_DIR)/systemd/system/" grub-btrfsd.service; \
+                sed 's:@__BIN_DIR__@:$(BIN_DIR):g' grub-btrfsd.service > "$(TEMP_DIR)/grub-btrfsd.service"; \
+                install -Dm644 -t "$(LIB_DIR)/systemd/system/" "$(TEMP_DIR)/grub-btrfsd.service"; \
 	 fi
 	@# OpenRC init system
 	@if test "$(OPENRC)" = true; then \

--- a/grub-btrfsd.service
+++ b/grub-btrfsd.service
@@ -17,7 +17,7 @@ EnvironmentFile=/etc/default/grub-btrfs/config
 # -l, --log-file        Specify a logfile to write to
 # -v, --verbose         Let the log of the daemon be more verbose
 # -s, --syslog          Write to syslog
-ExecStart=/usr/bin/grub-btrfsd --syslog /.snapshots
+ExecStart=@__BIN_DIR__@/grub-btrfsd --syslog /.snapshots
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The previous installation method did not take into account user defined bin paths.