### PR TITLE
Add noexec option to mount command

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -613,7 +613,7 @@ if [ -e "$grub_btrfs_directory/grub-btrfs.cfg" ]; then
 fi
 # Create mount point then mounting
 [ ! -d "$grub_btrfs_mount_point" ] && mkdir -p "$grub_btrfs_mount_point"
-mount -o ro,subvolid=5 /dev/disk/by-uuid/"$root_uuid" "$grub_btrfs_mount_point/" > /dev/null
+mount -o ro,noexec,subvolid=5 /dev/disk/by-uuid/"$root_uuid" "$grub_btrfs_mount_point/" > /dev/null
 trap "unmount_grub_btrfs_mount_point" EXIT # unmounting mount point on EXIT signal
 count_warning_menuentries=0 # Count menuentries
 count_limit_snap=0 # Count snapshots


### PR DESCRIPTION
Add mount option to avoid chkrootkit busyloop. Chkrootkit is malware detector which scans all execubables in /tmp file system branch and if snapshot (already scanned in live filesystem) is mounted with noexec-option, there's nothing suspicious.

Grub menu is generating succesfully and automount / unmount is 95% more reliable with chkrootkit than before mount option change.