### PR TITLE
Add option to use root=PARTUUID=... instead of root=UUID=...

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -151,13 +151,23 @@ CLASS="--class snapshots --class gnu-linux --class gnu --class os"
 oldIFS=$IFS
 ## Detect uuid requirement (lvm,btrfs...)
 check_uuid_required() {
-if [ "${root_uuid}" = "" ] || [ "${GRUB_DISABLE_LINUX_UUID}" = "true" ] \
-    || ! test -e "/dev/disk/by-uuid/${root_uuid}" \
-    || ( test -e "${root_device}" && uses_abstraction "${root_device}" lvm ); then
-    LINUX_ROOT_DEVICE=${root_device}
-else
-    LINUX_ROOT_DEVICE=UUID=${root_uuid}
-fi
+    # Use PARTUUID instead of UUID, can help in initramfs-less systems
+    if [ "$(echo "${GRUB_BTRFS_USE_PARTUUID}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
+        local partuuid_val=$(blkid -s PARTUUID -o value "${root_device}")
+        if [ -n "${partuuid_val}" ]; then
+            LINUX_ROOT_DEVICE="PARTUUID=${partuuid_val}"
+            return
+        fi
+    fi
+
+    # Original Logic
+    if [ "${root_uuid}" = "" ] || [ "${GRUB_DISABLE_LINUX_UUID}" = "true" ] \
+       || ! test -e "/dev/disk/by-uuid/${root_uuid}" \
+       || ( test -e "${root_device}" && uses_abstraction "${root_device}" lvm ); then
+        LINUX_ROOT_DEVICE=${root_device}
+    else
+        LINUX_ROOT_DEVICE=UUID=${root_uuid}
+    fi
 }
 ## Detect rootflags
 detect_rootflags()

--- a/config
+++ b/config
@@ -162,3 +162,8 @@ GRUB_BTRFS_IGNORE_PREFIX_PATH=("var/lib/docker" "@var/lib/docker" "@/var/lib/doc
 # Enable booting from snapshots stored on LUKS encrypted devices
 # Default: "false"
 #GRUB_BTRFS_ENABLE_CRYPTODISK="true"
+
+# Enables the use of root=PARTUUID=... instead of UUID
+# This can help initramfs-less systems to boot into snapshots
+# Default: "false"
+#GRUB_BTRFS_USE_PARTUUID="true"


### PR DESCRIPTION
This patch allows the user to choose if UUID or PARTUUID is passed to the kernel, helping to boot snapshots on a initramfs-less system. 
The kernel on its own lacks the tools necessary to read UUID from the available filesystems and find the correct one to use as root  (this is usually the job of the initramfs if you have one), so it must rely on either the device name (unreliable, can change spontaneously) or PARTUUID (read natively from the GPT, unchanging)