### PR TITLE
[BUGFIX] Btrfs can return multiple root devices which confuses things.

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -111,7 +111,7 @@ fi
 # -----------------------------------------------------------
 
 # ---------- Root partition ----------
-root_device="$(${grub_probe} --target=device /)"           # e.g. /dev/mapper/enc
+root_device="$(${grub_probe} --target=device / | head -1)"           # e.g. /dev/mapper/enc
 root_uuid="$(${grub_probe} --device "${root_device}" --target=fs_uuid 2>/dev/null)" || true
 
 # Fallback when grub-probe fails (encrypted container, detached header…)


### PR DESCRIPTION
Just pick the first returned root device.