### PR TITLE
Fix UUID extraction for root subvolume

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -122,7 +122,7 @@ fi
 
 # Root subvolume UUID
 root_uuid_subvolume="$(btrfs subvolume show / 2>/dev/null | \
-                       awk -F':' '/^\s*UUID/ {gsub(/^[ \t]+/, "", $2); print $2}')"
+                     grep -E '^\s+UUID' | awk -F' ' '{print $2}')"
 [ -z "$root_uuid_subvolume" ] && print_error "UUID of the root subvolume is not available"
 
 # ---------- Boot partition ----------


### PR DESCRIPTION
ubuntu24.04
Adding boot menu entry for UEFI Firmware Settings ...
Detecting snapshots ...
UUID of the root subvolume is not available
If you think an error has occurred, please file a bug report at "https://github.com/Antynea/grub-btrfs"
done