### PR TITLE
Add conditional check for UUID symlink before mounting

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -659,7 +659,7 @@ if [ -e "$grub_btrfs_directory/grub-btrfs.cfg" ]; then
 fi
 # Create mount point then mounting
 [ ! -d "$grub_btrfs_mount_point" ] && mkdir -p "$grub_btrfs_mount_point"
-mount -o ro,subvolid=5 /dev/disk/by-uuid/"$root_uuid" "$grub_btrfs_mount_point/" > /dev/null
+[ -L /dev/disk/by-uuid/"$root_uuid" ] && mount -o ro,subvolid=5 /dev/disk/by-uuid/"$root_uuid" "$grub_btrfs_mount_point/" > /dev/null || mount -o ro,subvolid=5 "$root_device" "$grub_btrfs_mount_point/" > /dev/null
 trap "unmount_grub_btrfs_mount_point" EXIT # unmounting mount point on EXIT signal
 count_warning_menuentries=0 # Count menuentries
 count_limit_snap=0 # Count snapshots


### PR DESCRIPTION
On Alpine and Gentoo /dev/disk/by-uuid/<root uuid> doesn't always exist. See https://github.com/Antynea/grub-btrfs/issues/332

Conditional check if symlink exists; otherwise fall back to using $root_device, which seems to work.