### PR TITLE
feat: add auto-detection for Fedora distribution

### DIFF
--- a/config
+++ b/config
@@ -3,6 +3,14 @@
 
 GRUB_BTRFS_VERSION=4.13-yabsnap_info_support-2024-03-06T13:43:57+00:00
 
+# Distribution specific auto-detection (e.g. Fedora)
+if [ -f /etc/fedora-release ]; then
+    GRUB_BTRFS_GRUB_DIRNAME="/boot/grub2"
+    GRUB_BTRFS_GBTRFS_DIRNAME="/boot/grub2"
+    GRUB_BTRFS_MKCONFIG="grub2-mkconfig"
+    GRUB_BTRFS_SCRIPT_CHECK="grub2-script-check"
+fi
+
 # Disable grub-btrfs.
 # Default: "false"
 #GRUB_BTRFS_DISABLE="true"


### PR DESCRIPTION
Fedora uses non-standard paths and command names for GRUB (e.g., /boot/grub2 instead of /boot/grub, and grub2-mkconfig). This change adds a conditional block to detect Fedora via /etc/fedora-release and automatically sets the appropriate variables, improving the out-of-the-box experience for Fedora users.