### PR TITLE
Fix portable awk UUID whitespace matching

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -122,7 +122,7 @@ fi
 
 # Root subvolume UUID
 root_uuid_subvolume="$(btrfs subvolume show / 2>/dev/null | \
-                       awk -F':' '/^\s*UUID/ {gsub(/^[ \t]+/, "", $2); print $2}')"
+                       awk -F':' '/^[[:space:]]*UUID/ {gsub(/^[ \t]+/, "", $2); print $2}')"
 [ -z "$root_uuid_subvolume" ] && print_error "UUID of the root subvolume is not available"
 
 # ---------- Boot partition ----------
@@ -138,7 +138,7 @@ fi
 # If /boot is not a Btrfs subvolume, reuse root subvol UUID
 boot_uuid_subvolume="$(
     btrfs subvolume show "${boot_directory}" 2>/dev/null | \
-        awk -F':' '/^\s*UUID/ {gsub(/^[ \t]+/, "", $2); print $2; exit}'
+        awk -F':' '/^[[:space:]]*UUID/ {gsub(/^[ \t]+/, "", $2); print $2; exit}'
 )"
 [ -z "$boot_uuid_subvolume" ] && boot_uuid_subvolume="$root_uuid_subvolume"
 


### PR DESCRIPTION
Possibly related to #220

On Kubuntu 25.10, grub-btrfs failed during grub-mkconfig with:

UUID of the root subvolume is not available

The root subvolume did have a UUID, but awk did not match it because \s is not portable in awk regular expressions. Replacing \s with POSIX [[:space:]] fixed detection and allowed snapshot entries to generate correctly.

Tested on Kubuntu 25.10 with Btrfs root subvolume @ and Snapper snapshots under @/.snapshots.