### PR TITLE
Fixed openrc init.d pidfile typo

### DIFF
--- a/grub-btrfsd.initd
+++ b/grub-btrfsd.initd
@@ -5,7 +5,7 @@
 name="grub-btrfs daemon"
 command="/usr/bin/grub-btrfsd"
 command_args="$optional_args ${snapshots}"
-pidfile="/run/{RC_SVCNAME}.pid"
+pidfile="/run/${RC_SVCNAME}.pid"
 command_background=true
 
 depend() {


### PR DESCRIPTION
Added "$" to `{RC_SVCNAME}` to ensure pid file is grub-btrfsd.pid and not "{RC_SVCNAME}.pid"