### PR TITLE
Added Debian Sysvinit support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PREFIX ?= /usr
 INITCPIO ?= false
 SYSTEMD ?= true
 OPENRC ?= false
+SYSVINIT ?= false
 
 BOOT_DIR_DEBIAN ?= /boot/grub
 BOOT_DIR_FEDORA ?= /boot/grub2
@@ -63,6 +64,10 @@ install:
 		echo "Installing openRC init.d & conf.d file"; \
 		install -Dm744 grub-btrfsd.initd "$(DESTDIR)/etc/init.d/grub-btrfsd"; \
 		install -Dm644 grub-btrfsd.confd "$(DESTDIR)/etc/conf.d/grub-btrfsd"; \
+	 fi
+	@if test "$(SYSVINIT)" = true; then \
+		echo "Installing sysvinit init.d file"; \
+		install -Dm755 grub-btrfsd.sysvinit.initd "$(DESTDIR)/etc/init.d/grub-btrfsd"; \
 	 fi
 	@# Arch Linux like distros only :
 	@if test "$(INITCPIO)" = true; then \

--- a/README.md
+++ b/README.md
@@ -274,6 +274,51 @@ After that, the daemon should be restarted with:
 sudo rc-service grub-btrfsd restart
 ```
 
+- - -
+#### grub-btrfsd Sysvinit instructions
+The sysvinit grub-btrfsd script is designed for Debian and
+Debian-based distributions using sysvinit (Devuan, MX Linux, etc). It depends on Linux
+Standards Base (LSB) init functions which are located at
+`/lib/lsb/init-functions` on Debian and Debian-derivatives. These functions may be located in a
+different directory in other distributions using sysvinit, and the
+functions contained therein may differ from those called in the script.
+
+To start the daemon run:
+```bash
+sudo service grub-btrfsd start
+```
+
+To activate it during system startup, run:
+```bash
+sudo update-rc.d grub-btrfsd defaults
+```
+
+##### 💼 Snapshots not in `/.snapshots` for Sysvinit
+By default the daemon is watching the directory `/.snapshots`. If the daemon should watch a different directory, it can be edited by passing different arguments to it.
+Arguments are passed to grub-btrfsd via `DAEMON_ARGS` and `SNAPSHOTS`
+variables in the script `/etc/init.d/grub-btrfsd`.
+The variable `SNAPSHOTS` defines the path the daemon will monitor for
+snapshots.
+
+After editing, the applicable portion of the file should look like this:
+
+``` bash
+SNAPSHOTS="/.snapshots" # Snapper in the root directory
+# SNAPSHOTS="/run/timeshift/backup/timeshift-btrfs/snapshots" # Timeshift < v22.06
+
+## Optional arguments to run with the daemon
+# Append options to this like this:
+# DAEMON_ARGS="--syslog --timeshift-auto --verbose"
+# Possible options are:
+# -t, --timeshift-auto  Automatically detect Timeshifts snapshot directory for timeshift >= 22.06
+# -o, --timeshift-old   Look for snapshots in directory of Timeshift <v22.06 (requires --timeshift-auto)
+# -l, --log-file        Specify a logfile to write to
+# -v, --verbose         Let the log of the daemon be more verbose
+# -s, --syslog          Write to syslog
+
+DAEMON_ARGS="--syslog"
+```
+
 ##### 🔒 Snapshots on LUKS encrypted devices
 By default, grub-btrfs generates entries that does not load modules for dealing with encrypted devices.
 Enable the `GRUB_BTRFS_ENABLE_CRYPTODISK` variable in `/etc/default/grub-btrfs/config` to load said modules and then execute the steps to mount encrypted root after selecting the snapshot.

--- a/grub-btrfsd.sysvinit.initd
+++ b/grub-btrfsd.sysvinit.initd
@@ -1,0 +1,102 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          grub-btrfsd
+# Required-Start:    $local_fs $syslog
+# Required-Stop:     $local_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Regenerate grub-btrfs.cfg
+# Description:       Monitors btrfs snapshots created with snapper
+#                    or Timeshift and automatically regenerates
+#                    grub-btrfs.cfg.
+### END INIT INFO
+
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+DESC="grub-btrfs snapshot daemon"
+NAME=grub-btrfsd
+DAEMON=/usr/bin/$NAME
+PIDFILE=/run/$NAME.pid
+
+SCRIPTNAME=/etc/init.d/$NAME
+
+SNAPSHOTS="/.snapshots" # Snapper in the root directory
+# SNAPSHOTS="/run/timeshift/backup/timeshift-btrfs/snapshots" # Timeshift < v22.06
+
+## Optional arguments to run with the daemon
+# Append options to this like this:
+# DAEMON_ARGS="--syslog --timeshift-auto --verbose"
+# Possible options are:
+# -t, --timeshift-auto  Automatically detect Timeshifts snapshot directory for timeshift >= 22.06
+# -o, --timeshift-old   Look for snapshots in directory of Timeshift <v22.06 (requires --timeshift-auto)
+# -l, --log-file        Specify a logfile to write to
+# -v, --verbose         Let the log of the daemon be more verbose
+# -s, --syslog          Write to syslog
+
+DAEMON_ARGS="--syslog" # Snapper
+# DAEMON_ARGS="--syslog --timeshift-auto --verbose" # Timeshift >= 22.06
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Load LSB init functions.
+# This is the path for Debian and Devuan, may vary on other distributions.
+. /lib/lsb/init-functions
+
+do_start() {
+    start-stop-daemon \
+        --start \
+        --background \
+        --make-pidfile \
+        --pidfile "$PIDFILE" \
+        --exec "$DAEMON" -- \
+        $DAEMON_ARGS \
+        "$SNAPSHOTS"
+}
+
+do_stop() {
+    start-stop-daemon \
+        --stop \
+        --quiet \
+        --retry=TERM/30/KILL/5 \
+        --pidfile "$PIDFILE"
+}
+
+case "$1" in
+    start)
+        log_daemon_msg "Starting $DESC" "$NAME"
+        if do_start; then
+            log_end_msg 0
+        else
+            log_end_msg 1
+        fi
+        ;;
+    stop)
+        log_daemon_msg "Stopping $DESC" "$NAME"
+        if do_stop; then
+            log_end_msg 0
+        else
+            log_end_msg 1
+        fi
+        ;;
+    restart|force-reload)
+        log_daemon_msg "Restarting $DESC" "$NAME"
+        do_stop
+        sleep 1
+        if do_start; then
+            log_end_msg 0
+        else
+            log_end_msg 1
+        fi
+        ;;
+    status)
+        status_of_proc -p "$PIDFILE" "$DAEMON" "$NAME"
+        exit $?
+        ;;
+    *)
+        echo "Usage: $SCRIPTNAME {start|stop|restart|force-reload|status}"
+        exit 2
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
Correction to #436. 

I recently wrote a sysvinit script for a couple of Debian and Devuan machines I have running sysvinit and figured I'd share.

As-is it will only work with Debian-based distributions because of historic differences in LSB init functions called in the script, but to my knowledge Debian is the only large project to support sysvinit, and the only remaining sysvinit distributions who use sysvinit for service management are Debian-based (there are a couple that use sysvinit for init only and something else for service management).

No worries if you aren't interested in merging, I'll keep the sysvinit script posted on my profile for anyone interested.