### PR TITLE
Fix: Replace Perl-compatible \s with POSIX [ \t] in awk expressions for mawk compatibility

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -131,7 +131,7 @@ fi
 
 # Root subvolume UUID
 root_uuid_subvolume="$(btrfs subvolume show / 2>/dev/null | \
-                       awk -F':' '/^\s*UUID/ {gsub(/^[ \t]+/, "", $2); print $2}')"
+                       awk -F':' '/^[ \t]*UUID/ {gsub(/^[ \t]+/, "", $2); print $2}')"
 [ -z "$root_uuid_subvolume" ] && print_error "UUID of the root subvolume is not available"
 
 # ---------- Boot partition ----------
@@ -147,7 +147,7 @@ fi
 # If /boot is not a Btrfs subvolume, reuse root subvol UUID
 boot_uuid_subvolume="$(
     btrfs subvolume show "${boot_directory}" 2>/dev/null | \
-        awk -F':' '/^\s*UUID/ {gsub(/^[ \t]+/, "", $2); print $2; exit}'
+        awk -F':' '/^[ \t]*UUID/ {gsub(/^[ \t]+/, "", $2); print $2; exit}'
 )"
 [ -z "$boot_uuid_subvolume" ] && boot_uuid_subvolume="$root_uuid_subvolume"
 


### PR DESCRIPTION
### What was done:
Replaced the Perl-compatible regex escape sequence `\s` with the POSIX-compliant character class `[ \t]` in the `awk` expressions used to parse the UUID output from `btrfs subvolume show`.

### Why it was done:
Currently, the script uses `\s` to match whitespace before `UUID:` in the `awk` command. While GNU `awk` (`gawk`) supports PCRE sequences like `\s`, standard POSIX `awk` implementations—most notably `mawk`, which is the default on Debian, Ubuntu, and their derivatives (like Linux Mint/LMDE)—do not support `\s`. When `mawk` evaluates `/^\s*UUID/`, it fails to match the whitespace, returning an empty UUID string. This causes a total failure during `grub-mkconfig` with the error: `UUID of the root subvolume is not available`.

### What it solves:
This change ensures the script correctly identifies the UUID of the root and boot subvolumes on distributions utilizing `mawk` as the default `awk` implementation, preventing `grub-mkconfig` from crashing.

### Regression risk:
**None.** The `[ \t]` character class is universally supported by the POSIX regular expression standard. It works flawlessly out-of-the-box on both `gawk` and `mawk`, meaning this fix maintains full backward compatibility with systems that currently use GNU `awk`, while seamlessly adding support for Debian-based systems.